### PR TITLE
Add section about 'presentation request'

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1102,6 +1102,24 @@ format-related rules above:
 }
 ```
 
+### Presentation Definition Envelopes
+Presentation Definitions may be sent from a Verifier to a Holder using a wide
+variety of transport mechanisms or credentials exchange protocols. This
+specification does not define a transport mechanism for `Presentation
+Definitions` (or `Presentation Request`), but does note that different use
+cases, supported signature schemes, protocols, and threat models may require a
+`Presentation Request` to have certain properties:
+- Signature verification - A Holder may wish to have assurances as to the
+  provenance, identity, or status of a `Presentation Definition`. In this case,
+  a `Presentation Request` that uses digital signatures may be required. 
+- `domain`, `challenge`, or `nonce` - Some presentation protocols may require
+  that presentations be unique, i.e., it should be possible for a Verifier to
+  detect if a presentation has been used before. Other protocols may require
+  that a presentation to be bound to a particular communication exchange, or
+  session. In these cases, a `Presentation Request` that provides a `domain`,
+  `challenge`,or `nonce` property may be required.
+
+
 ## Presentation Submission
 
 _Presentation Submissions_ are objects embedded within target credential

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1102,7 +1102,7 @@ format-related rules above:
 }
 ```
 
-### Presentation Definition Envelopes
+### Presentation Requests
 Presentation Definitions may be sent from a Verifier to a Holder using a wide
 variety of transport mechanisms or credentials exchange protocols. This
 specification does not define a transport mechanism for `Presentation


### PR DESCRIPTION
This PR adds a section about `presentation requests` says this spec doesn't define them, and then points out two properties it may be nice for a `presentation request` to have.

This PR fixes #23 #29 #51 #52 and may also address #34 

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>