### PR TITLE
Differentiate format and type

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,8 @@ proofs may satisfy an input requirement.</p>
             <span class="token punctuation">{</span>
               <span class="token property">"path"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token string">"$.credentialSubject.birth_date"</span><span class="token punctuation">,</span> <span class="token string">"$.vc.credentialSubject.birth_date"</span><span class="token punctuation">,</span> <span class="token string">"$.birth_date"</span><span class="token punctuation">]</span><span class="token punctuation">,</span>
               <span class="token property">"filter"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
+                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+                <span class="token property">"format"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
                 <span class="token property">"minimum"</span><span class="token operator">:</span> <span class="token string">"1999-5-16"</span>
               <span class="token punctuation">}</span>
             <span class="token punctuation">}</span>
@@ -247,7 +248,8 @@ proofs may satisfy an input requirement.</p>
             <span class="token punctuation">{</span>
               <span class="token property">"path"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token string">"$.credentialSubject.dob"</span><span class="token punctuation">,</span> <span class="token string">"$.vc.credentialSubject.dob"</span><span class="token punctuation">,</span> <span class="token string">"$.dob"</span><span class="token punctuation">]</span><span class="token punctuation">,</span>
               <span class="token property">"filter"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
+                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+                <span class="token property">"format"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
                 <span class="token property">"maximum"</span><span class="token operator">:</span> <span class="token string">"1999-5-16"</span>
               <span class="token punctuation">}</span>
             <span class="token punctuation">}</span>
@@ -266,7 +268,8 @@ proofs may satisfy an input requirement.</p>
             <span class="token punctuation">{</span>
               <span class="token property">"path"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token string">"$.credentialSubject.birth_date"</span><span class="token punctuation">,</span> <span class="token string">"$.vc.credentialSubject.birth_date"</span><span class="token punctuation">,</span> <span class="token string">"$.birth_date"</span><span class="token punctuation">]</span><span class="token punctuation">,</span>
               <span class="token property">"filter"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
+                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+                <span class="token property">"format"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
                 <span class="token property">"maximum"</span><span class="token operator">:</span> <span class="token string">"1999-5-16"</span>
               <span class="token punctuation">}</span>
             <span class="token punctuation">}</span>
@@ -425,7 +428,8 @@ proofs may satisfy an input requirement.</p>
             <span class="token punctuation">{</span>
               <span class="token property">"path"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token string">"$.credentialSubject.dob"</span><span class="token punctuation">,</span> <span class="token string">"$.vc.credentialSubject.dob"</span><span class="token punctuation">,</span> <span class="token string">"$.dob"</span><span class="token punctuation">]</span><span class="token punctuation">,</span>
               <span class="token property">"filter"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
+                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+                <span class="token property">"format"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
                 <span class="token property">"minimum"</span><span class="token operator">:</span> <span class="token string">"1999-5-16"</span>
               <span class="token punctuation">}</span>
             <span class="token punctuation">}</span>
@@ -444,7 +448,8 @@ proofs may satisfy an input requirement.</p>
             <span class="token punctuation">{</span>
               <span class="token property">"path"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token string">"$.credentialSubject.birth_date"</span><span class="token punctuation">,</span> <span class="token string">"$.vc.credentialSubject.birth_date"</span><span class="token punctuation">,</span> <span class="token string">"$.birth_date"</span><span class="token punctuation">]</span><span class="token punctuation">,</span>
               <span class="token property">"filter"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
+                <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+                <span class="token property">"format"</span><span class="token operator">:</span> <span class="token string">"date"</span><span class="token punctuation">,</span>
                 <span class="token property">"minimum"</span><span class="token operator">:</span> <span class="token string">"1999-5-16"</span>
               <span class="token punctuation">}</span>
             <span class="token punctuation">}</span>
@@ -1060,6 +1065,7 @@ format-related rules above:</p>
           <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"object"</span><span class="token punctuation">,</span>
           <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
             <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span> <span class="token punctuation">}</span><span class="token punctuation">,</span>
+            <span class="token property">"format"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span> <span class="token punctuation">}</span><span class="token punctuation">,</span>
             <span class="token property">"pattern"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span> <span class="token punctuation">}</span><span class="token punctuation">,</span>
             <span class="token property">"minimum"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span> <span class="token punctuation">}</span><span class="token punctuation">,</span>
             <span class="token property">"minLength"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"integer"</span> <span class="token punctuation">}</span><span class="token punctuation">,</span>

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -184,7 +184,8 @@ proofs may satisfy an input requirement.
             {
               "path": ["$.credentialSubject.birth_date", "$.vc.credentialSubject.birth_date", "$.birth_date"],
               "filter": {
-                "type": "date",
+                "type": "string",
+                "format": "date",
                 "minimum": "1999-5-16"
               }
             }
@@ -234,7 +235,8 @@ proofs may satisfy an input requirement.
             {
               "path": ["$.credentialSubject.dob", "$.vc.credentialSubject.dob", "$.dob"],
               "filter": {
-                "type": "date",
+                "type": "string",
+                "format": "date",
                 "maximum": "1999-5-16"
               }
             }
@@ -253,7 +255,8 @@ proofs may satisfy an input requirement.
             {
               "path": ["$.credentialSubject.birth_date", "$.vc.credentialSubject.birth_date", "$.birth_date"],
               "filter": {
-                "type": "date",
+                "type": "string",
+                "format": "date",
                 "maximum": "1999-5-16"
               }
             }
@@ -417,7 +420,8 @@ proofs may satisfy an input requirement.
             {
               "path": ["$.credentialSubject.dob", "$.vc.credentialSubject.dob", "$.dob"],
               "filter": {
-                "type": "date",
+                "type": "string",
+                "format": "date",
                 "minimum": "1999-5-16"
               }
             }
@@ -436,7 +440,8 @@ proofs may satisfy an input requirement.
             {
               "path": ["$.credentialSubject.birth_date", "$.vc.credentialSubject.birth_date", "$.birth_date"],
               "filter": {
-                "type": "date",
+                "type": "string",
+                "format": "date",
                 "minimum": "1999-5-16"
               }
             }
@@ -1074,6 +1079,7 @@ format-related rules above:
           "type": "object",
           "properties": {
             "type": { "type": "string" },
+            "format": { "type": "string" },
             "pattern": { "type": "string" },
             "minimum": { "type": "string" },
             "minLength": { "type": "integer" },

--- a/test/presentation-definition/schema.json
+++ b/test/presentation-definition/schema.json
@@ -87,6 +87,7 @@
           "type": "object",
           "properties": {
             "type": { "type": "string" },
+            "format": { "type": "string" },
             "pattern": { "type": "string" },
             "minimum": { "type": "string" },
             "minLength": { "type": "integer" },


### PR DESCRIPTION
Prior to this PR we've been overloading "type" with "format", which is not valid JSON Schema. This PR extends examples and the JSON Schema to include the "format" field.

Ref: https://json-schema.org/understanding-json-schema/reference/string.html#format