### PR TITLE
fix input evaluation to match predicate input descriptor language

### DIFF
--- a/index.html
+++ b/index.html
@@ -1149,10 +1149,12 @@ candidate input.</li>
 <li>If the <code>filter</code> property of the field entry is present, validate the
 <em>Field Query Result</em> from the step above against the
 <a href="https://json-schema.org/specification.html">JSON Schema</a> descriptor value.</li>
-<li>If the <code>predicate</code> property of the field entry is present, derive a
-<em>Field Query Predicate</em> boolean value using the value of the <em>Field
-Query Result</em> obtained above, according to the <code>operation</code> and <code>p_value</code>
-or <code>p_set</code> provided in the <code>predicate</code> object.</li>
+<li>If the <code>predicate</code> property of the field entry is present, a boolean
+value should be returned rather than the value of the <em>Field Query
+Result</em>. Calculate this boolean value by evaluating the <em>Field Query
+Result</em> against the
+<a href="https://json-schema.org/specification.html">JSON Schema</a> descriptor
+value of the <code>filter</code> property.</li>
 <li>If the result is valid, proceed iterating the rest of the <code>fields</code> entries.</li>
 </ol>
 </li>
@@ -1508,7 +1510,7 @@ within.</li>
 <li>The object <strong><strong>MUST</strong></strong> include a <code>format</code> property, and its value
 <strong><strong>MUST</strong></strong> be a string value matching one of the
 <a href="#credential-format-designations">Credential Format Designation</a> (<code>jwt</code>,
-<code>jwt_vc</code>, <code>jwt_vp</code>), to denote what data format the credential is being
+<code>jwt_vc</code>, <code>jwt_vp</code>, <code>ldp_vc</code>, <code>ldp_vp</code>, <code>ldp</code>), to denote what data format the credential is being
 submitted in.</li>
 </ul>
 </li>
@@ -1722,18 +1724,18 @@ the top level of the embed target, the location is described in JSONPath syntax.
   <span class="token punctuation">}</span><span class="token punctuation">,</span>
   <span class="token property">"_claim_sources"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
     <span class="token property">"banking_input_2"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-      <span class="token property">"JWT"</span><span class="token operator">:</span> "eyJhbGciOiJSUzI<span class="token number">1</span>NiIsInR<span class="token number">5</span>cCI<span class="token number">6</span>IkpXVCJ<span class="token number">9.</span>eyJpc<span class="token number">3</span>MiOiJodHRwcz
-      ovL<span class="token number">3</span>NlcnZlci<span class="token number">5</span>vdGhlcm<span class="token number">9</span>wLmNvbSIsInN<span class="token number">1</span>YiI<span class="token number">6</span>ImU<span class="token number">4</span>MTQ<span class="token number">4</span>NjAzLTg<span class="token number">5</span>MzQtNDI<span class="token number">0</span>N
-      S<span class="token number">04</span>MjViLWMxMDhiOGI<span class="token number">2</span>Yjk<span class="token number">0</span>NSIsInZlcmlmaWVkX<span class="token number">2</span>NsYWltcyI<span class="token number">6</span>eyJ<span class="token number">2</span>ZXJpZmlj
-      YXRpb<span class="token number">24</span>iOnsidHJ<span class="token number">1</span>c<span class="token number">3</span>RfZnJhbWV<span class="token number">3</span>b<span class="token number">3</span>JrIjoiaWFsX<span class="token number">2</span>V<span class="token number">4</span>YW<span class="token number">1</span>wbGVfZ<span class="token number">29</span>sZCJ<span class="token number">9</span>LCJ
-      jbGFpbXMiOnsiZ<span class="token number">2</span>l<span class="token number">2</span>ZW<span class="token number">5</span>fbmFtZSI<span class="token number">6</span>Ik<span class="token number">1</span>heCIsImZhbWlseV<span class="token number">9</span>uYW<span class="token number">1</span>lIjoiTWVpZX
-      IiLCJiaXJ<span class="token number">0</span>aGRhdGUiOiIxOTU<span class="token number">2</span>LTAxLTI<span class="token number">4</span>In<span class="token number">19</span>fQ.FArlPUtUVn<span class="token number">95</span>HCExePlWJQ
-      <span class="token number">6</span>ctVfVpQyeSbe<span class="token number">3</span>xkH<span class="token number">9</span>MH<span class="token number">1</span>QJjnk<span class="token number">5</span>GVbBW<span class="token number">0</span>qe<span class="token number">1</span>b<span class="token number">7</span>R<span class="token number">3</span>lE<span class="token number">-8</span>iVv__<span class="token number">0</span>mhRTUI<span class="token number">5</span>lcFhLj
-      oGjDS<span class="token number">8</span>zgWSarVsEEjwBK<span class="token number">7</span>WD<span class="token number">3</span>r<span class="token number">9</span>cEw<span class="token number">6</span>ZAhfEkhHL<span class="token number">9</span>eqAaED<span class="token number">2</span>rhhDbHD<span class="token number">5</span>dZWXkJCu
-      XIcn<span class="token number">65</span>g<span class="token number">6</span>rryiBanxlXK<span class="token number">0</span>ZmcK<span class="token number">4</span>fD<span class="token number">9</span>HV<span class="token number">9</span>MFduk<span class="token number">0</span>LRG_p<span class="token number">4</span>yocMaFvVkqawat<span class="token number">5</span>NV<span class="token number">9</span>QQ
-      <span class="token number">3</span>ij<span class="token number">7</span>UBr<span class="token number">3</span>G<span class="token number">7</span>A<span class="token number">4</span>FojcKEkoJKScdGoozir<span class="token number">8</span>m<span class="token number">5</span>XD<span class="token number">83</span>Sn<span class="token number">45</span>_<span class="token number">79</span>nCcgWSnCX<span class="token number">2</span>QTukL<span class="token number">8</span>Ny
-      wIItu_K<span class="token number">48</span>cjHiAGXXSzydDm_ccGCe<span class="token number">0</span>sY-Ai<span class="token number">2</span>-iFFuQo<span class="token number">2</span>PtfuK<span class="token number">2</span>SqPPmAZJxEFrF
-      oLY<span class="token number">4</span>g"
+      <span class="token property">"JWT"</span><span class="token operator">:</span> "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwcz
+      ovL3NlcnZlci5vdGhlcm9wLmNvbSIsInN1YiI6ImU4MTQ4NjAzLTg5MzQtNDI0N
+      S04MjViLWMxMDhiOGI2Yjk0NSIsInZlcmlmaWVkX2NsYWltcyI6eyJ2ZXJpZmlj
+      YXRpb24iOnsidHJ1c3RfZnJhbWV3b3JrIjoiaWFsX2V4YW1wbGVfZ29sZCJ9LCJ
+      jbGFpbXMiOnsiZ2l2ZW5fbmFtZSI6Ik1heCIsImZhbWlseV9uYW1lIjoiTWVpZX
+      IiLCJiaXJ0aGRhdGUiOiIxOTU2LTAxLTI4In19fQ.FArlPUtUVn95HCExePlWJQ
+      6ctVfVpQyeSbe3xkH9MH1QJjnk5GVbBW0qe1b7R3lE-8iVv__0mhRTUI5lcFhLj
+      oGjDS8zgWSarVsEEjwBK7WD3r9cEw6ZAhfEkhHL9eqAaED2rhhDbHD5dZWXkJCu
+      XIcn65g6rryiBanxlXK0ZmcK4fD9HV9MFduk0LRG_p4yocMaFvVkqawat5NV9QQ
+      3ij7UBr3G7A4FojcKEkoJKScdGoozir8m5XD83Sn45_79nCcgWSnCX2QTukL8Ny
+      wIItu_K48cjHiAGXXSzydDm_ccGCe0sY-Ai2-iFFuQo2PtfuK2SqPPmAZJxEFrF
+      oLY4g"
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
     <span class="token property">"employment_input"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
       <span class="token property">"VC"</span><span class="token operator">:</span> <span class="token punctuation">{</span>

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1140,10 +1140,12 @@ Evaluate each candidate input as follows:
       2. If the `filter` property of the field entry is present, validate the
         _Field Query Result_ from the step above against the
         [JSON Schema](https://json-schema.org/specification.html) descriptor value.
-      3. If the `predicate` property of the field entry is present, derive a
-        _Field Query Predicate_ boolean value using the value of the _Field
-        Query Result_ obtained above, according to the `operation` and `p_value`
-        or `p_set` provided in the `predicate` object.
+      3. If the `predicate` property of the field entry is present, a boolean
+        value should be returned rather than the value of the _Field Query
+        Result_. Calculate this boolean value by evaluating the _Field Query
+        Result_ against the
+        [JSON Schema](https://json-schema.org/specification.html) descriptor
+        value of the `filter` property.         
       4. If the result is valid, proceed iterating the rest of the `fields` entries.
   3. If all of the previous validation steps are successful, mark the candidate
     input as a match for use in a _Presentation Submission_, and if present at


### PR DESCRIPTION
Removes old predicate property object names and fixes input evaluation to conform to the predicate input descriptor section.
Signed-off-by: Brent Zundel <brent.zundel@gmail.com>