### PR TITLE
Holder bindings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1263,6 +1263,48 @@ information to resolve the status of a claim.</p>
 </div>
 </section>
 </tab-panel>
+<h4 id="holder-binding"><a class="toc-anchor" href="#holder-binding">§</a> Holder Binding</h4>
+<p>Credential often rely on proofs of holder binding for their validity. For
+example, a credential may be bound to a holder through the use of an identifier,
+knowledge of a secret, or via a biometric. A verifier may wish to determine that
+a particular credential, or set of credentials is bound to the credential
+holder. This can help the verifier to determine the legitimacy of the presented
+proofs.</p>
+<h5 id="proof-of-identifier-control"><a class="toc-anchor" href="#proof-of-identifier-control">§</a> Proof of Identifier Control</h5>
+<p>A number of credential types include an identifier for the credential subject.
+A verifier may wish to ascertain that the subject identified in the credential
+is the one submitting the proof, or has consented to the proof submission.</p>
+<p>One mechanism for providing such proofs is the use of a DID as the identifier
+for the credential subject. DIDs enable an entity to provide a cryptographic
+proof of control of the identifier, usually through a demonstration that the
+holder knows some secret value, such as a private key. The holder can
+demonstrate the same proof of control when presenting the credential. In
+addition to verifying the authenticity and origin of the credential itself, a
+verifier can verify that the presenter of the credential still controls the
+identifier.</p>
+<h5 id="link-secrets"><a class="toc-anchor" href="#link-secrets">§</a> Link Secrets</h5>
+<p>Some credential signatures support the inclusion of holder-provided information
+that becomes incorporated into the signature, but remains hidden from the
+credential issuer. One common use of this capability is known as a link secret.
+A <code>link secret</code> is a value known only to the credential holder that is embedded
+in the signature of each issued credential. Upon presentation to a verifier, the
+holder demonstrates knowledge of the random value without revealing it, and
+proves that the same value is contained in every credential included in the
+proof presentation. The verifier can verify that the presenter of the
+credentials knows the link secret, and that the <code>link secret</code> is the same in
+each credential.</p>
+<h6 id="common-values-across-credentials"><a class="toc-anchor" href="#common-values-across-credentials">§</a> Common values across credentials</h6>
+<p>Though not of itself a means of binding to a holder, multiple credentials with
+common values may be taken by a verifier as an indication that the credentials
+are about the same subject. For example, if multiple banking credentials contain
+the same account number, and one of those credentials may be bound to the holder
+using any of the mechanisms described here, a verifier could rely on the
+demonstration of common values to bind all of the credentials to the holder.</p>
+<h5 id="biometrics"><a class="toc-anchor" href="#biometrics">§</a> Biometrics</h5>
+<p>This type of holder binding, instead of relying on demonstrating knowledge of
+some secret value, relies on the evaluation of biometric data. There are a
+number of mechanisms for safely embedding biometric information in a credential
+such that only a person who can confirm the biometric may use the credential.</p>
 <h3 id="json-schema-2"><a class="toc-anchor" href="#json-schema-2">§</a> JSON Schema</h3>
 <p>The following JSON Schema Draft 7 definition summarizes the
 format-related rules above:</p>
@@ -2257,6 +2299,7 @@ specification that call for JSONPath expression execution.</p>
 <li><a href="#input-evaluation">Input Evaluation</a>
 <ul>
 <li><a href="#expired-and-revoked-data">Expired and Revoked Data</a></li>
+<li><a href="#holder-binding">Holder Binding</a></li>
 </ul>
 </li>
 <li><a href="#json-schema-2">JSON Schema</a></li>

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -987,29 +987,33 @@ Descriptor Objects_ are composed as follows:
         application `presentation definition` might contain an [[ref:Input Descriptor]]
         object for an essay submission. In this case, the [[ref:Verifier]] would be able
         to require that the essay be provided by the one submits the application. 
-      - The object ****MAY**** contain a `subject_is_holder` property, and if
-        present its value ****MUST**** be an object composed as follows:
-        - The object ****MAY**** contain an `subject` property, and if present
-          its value ****MUST**** be a string which indicates the `type` value
-          of the claim subject which must be the same as the entity submitting
-          the response. When requesting presentation of a claim with only one
-          subject, the verifier may omit this property. 
-        - The object ****MUST**** contain a `status` property and its value
-          ****MUST**** be one of the following strings:
+      - The object ****MAY**** contain an `is_holder` property, and if
+        present its value ****MUST**** be an object of key-value pairs composed
+        as follows:
+        - Each key ****MUST**** be the string value from a 
+          [_Input Descriptor Field Entry_](#input-descriptor-field-entry)
+          object's `id` property. This identifies the attribute whose subject is
+          of concern to the verifier.  
+        - The corresponding value ****MUST**** be one of the following strings:
           - `required` - This indicates that the processing entity ****MUST****
-            include proof that the subject of the claim is the same as the
-            entity submitting the response.
+            include proof that the subject of the attribute identified by the
+            key is the same as the entity submitting the response.
           - `preferred` - This indicates that it is ****RECOMMENDED**** that the
-            processing entity include proof that the subject of the claim is
-            the same as the entity submitting the response, i.e., the holder.
-      
-        The `subject_is_holder` property would be used by a [[ref:Verifier]] to
+            processing entity include proof that the subject of the attribute
+            identified by the key is the same as the entity submitting the
+            response.
+                                          
+        The `is_holder` property would be used by a [[ref:Verifier]] to
         require that certain inputs be provided by a certain subject. For
         example, an identity verification `presentation definition` might
-        contain an _Input Descriptor_ object for a birthdate. In this case, the
-        [[ref:Verifier]] would be able to require that the birth certificate
-        claim was issued to the claim subject with `type` "mother", who is the
-        same as the one who submits the identity verification. 
+        contain an _Input Descriptor_ object for a birthdate from a birth
+        certificate. In this case, the [[ref:Verifier]] would be able to require
+        that the holder of the birth certificate claim is the same as the
+        subject of the birthdate attribute. This is useful in cases where a
+        claim may have multiple subjects.
+        
+        For more information about techniques used to prove binding to a holder,
+        please see [_Holder Binding_](#holder-binding). 
         
       - The object ****MAY**** contain a `fields` property, and its value
         ****MUST**** be an array of
@@ -1029,6 +1033,9 @@ Descriptor Objects_ are composed as follows:
             JSON-LD/JWT-based
             [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) and
             vanilla JSON Web Tokens (JWTs) [[spec:rfc7797]].
+          - The object ****MAY**** contain an `id` property, and if present
+            its value ****MUST**** be a string that is unique from any other
+            field object's `id` property.
           - The object ****MAY**** contain a `purpose` property, and if present
             its value ****MUST**** be a string that describes the purpose for
             which the field is being requested.
@@ -1197,12 +1204,11 @@ Evaluate each candidate input as follows:
   5. If the `constraints` property of the [[ref:Input Descriptor]] is present, and it
     contains a `subject_is_issuer` property set to the value `required`, ensure
     that any submission of data in relation to the candidate input is fulfilled
-    using a _self_attested_ claims.
+    using a _self_attested_ claim.
   6. If the `constraints` property of the [[ref:Input Descriptor]] is present,
-    and it contains a `subject_is_holder` property with a `status` property set
-    to the value `required`, ensure that any submission of data in relation to
-    the candidate input is fulfilled by the subject of the claim indicated by
-    the value of the `subject` property.
+    and it contains an `is_holder` property, ensure that for each key in the
+    array, any submission of data in relation to the candidate input is
+    fulfilled by the subject of the attribute so identified.
 
 ::: note
 The above evaluation process assumes the User Agent will test each candidate
@@ -1478,7 +1484,7 @@ format-related rules above:
               "type": "string",
               "enum": ["required", "preferred"]
             },
-            "subject_is_holder": {
+            "is_holder": {
               "type": "object",
                 "properties":  {
                   "status": {

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1027,20 +1027,24 @@ Descriptor Objects_ are composed as follows:
         object for an essay submission. In this case, the [[ref:Verifier]] would be able
         to require that the essay be provided by the one submits the application. 
       - The object ****MAY**** contain an `is_holder` property, and if
-        present its value ****MUST**** be an object of key-value pairs composed
-        as follows:
-        - Each key ****MUST**** be the string value from a 
+        present its value ****MUST**** be an array of objects composed as
+        follows:
+        - The object ****MUST**** contain a `field_id` property. The value of
+           this property ****MUST**** be an array of strings, with each string
+           matching the string value from a 
           [_Input Descriptor Field Entry_](#input-descriptor-field-entry)
           object's `id` property. This identifies the attribute whose subject is
           of concern to the verifier.  
-        - The corresponding value ****MUST**** be one of the following strings:
+        - The object ****MUST**** contain a `directive` property. The value of
+          this property ****MUST****  be one of the following strings:
           - `required` - This indicates that the processing entity ****MUST****
-            include proof that the subject of the attribute identified by the
-            key is the same as the entity submitting the response.
+            include proof that the subject of each attribute identified by a
+            value in the `field_id` array is the same as the entity submitting
+            the response.
           - `preferred` - This indicates that it is ****RECOMMENDED**** that the
-            processing entity include proof that the subject of the attribute
-            identified by the key is the same as the entity submitting the
-            response.
+            processing entity include proof that the subject of each attribute
+            identified by a value in the `field_id` array is the same as the
+            entity submitting the response.
                                           
         The `is_holder` property would be used by a [[ref:Verifier]] to
         require that certain inputs be provided by a certain subject. For
@@ -1048,8 +1052,8 @@ Descriptor Objects_ are composed as follows:
         contain an _Input Descriptor_ object for a birthdate from a birth
         certificate. In this case, the [[ref:Verifier]] would be able to require
         that the holder of the birth certificate claim is the same as the
-        subject of the birthdate attribute. This is useful in cases where a
-        claim may have multiple subjects.
+        subject of the birthdate attribute. This is especially useful in cases
+        where a claim may have multiple subjects.
         
         For more information about techniques used to prove binding to a holder,
         please see [_Holder Binding_](#holder-binding). 
@@ -1245,9 +1249,10 @@ Evaluate each candidate input as follows:
     that any submission of data in relation to the candidate input is fulfilled
     using a _self_attested_ claim.
   6. If the `constraints` property of the [[ref:Input Descriptor]] is present,
-    and it contains an `is_holder` property, ensure that for each key in the
+    and it contains an `is_holder` property, ensure that for each object in the
     array, any submission of data in relation to the candidate input is
-    fulfilled by the subject of the attribute so identified.
+    fulfilled by the subject of the attributes so identified by the strings in
+    the `field_id` array.
 
 ::: note
 The above evaluation process assumes the User Agent will test each candidate
@@ -1531,15 +1536,20 @@ format-related rules above:
               "enum": ["required", "preferred"]
             },
             "is_holder": {
-              "type": "object",
+              "type": "array",
+              "items": {
+                "type": "object",
                 "properties":  {
-                  "status": {
+                  "field_id": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "directive": {
                     "type": "string",
                     "enum": ["required", "preferred"]
-                  },
-                  "subject": { "type": "string" }
+                  }
                 },
-                "required": ["status"],
+                "required": ["field_id", "directive"],
                 "additionalProperties": false
               }
             }
@@ -1555,6 +1565,7 @@ format-related rules above:
       "oneOf": [
         {
           "properties": {
+            "id": { "type": "string" },
             "path": {
               "type": "array",
               "items": { "type": "string" }
@@ -1567,6 +1578,7 @@ format-related rules above:
         },
         {
           "properties": {
+            "id": { "type": "string" },
             "path": {
               "type": "array",
               "items": { "type": "string" }

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1293,6 +1293,54 @@ information to resolve the status of a claim.
 
 </tab-panel>
 
+#### Holder Binding
+Credential often rely on proofs of holder binding for their validity. For
+example, a credential may be bound to a holder through the use of an identifier,
+knowledge of a secret, or via a biometric. A verifier may wish to determine that
+a particular credential, or set of credentials is bound to the credential
+holder. This can help the verifier to determine the legitimacy of the presented
+proofs.
+
+##### Proof of Identifier Control
+A number of credential types include an identifier for the credential subject.
+A verifier may wish to ascertain that the subject identified in the credential
+is the one submitting the proof, or has consented to the proof submission.
+
+One mechanism for providing such proofs is the use of a DID as the identifier
+for the credential subject. DIDs enable an entity to provide a cryptographic
+proof of control of the identifier, usually through a demonstration that the
+holder knows some secret value, such as a private key. The holder can
+demonstrate the same proof of control when presenting the credential. In
+addition to verifying the authenticity and origin of the credential itself, a
+verifier can verify that the presenter of the credential still controls the
+identifier.
+
+##### Link Secrets
+Some credential signatures support the inclusion of holder-provided information
+that becomes incorporated into the signature, but remains hidden from the
+credential issuer. One common use of this capability is known as a link secret.
+A `link secret` is a value known only to the credential holder that is embedded
+in the signature of each issued credential. Upon presentation to a verifier, the
+holder demonstrates knowledge of the random value without revealing it, and
+proves that the same value is contained in every credential included in the
+proof presentation. The verifier can verify that the presenter of the
+credentials knows the link secret, and that the `link secret` is the same in
+each credential.
+
+###### Common values across credentials
+Though not of itself a means of binding to a holder, multiple credentials with
+common values may be taken by a verifier as an indication that the credentials
+are about the same subject. For example, if multiple banking credentials contain
+the same account number, and one of those credentials may be bound to the holder
+using any of the mechanisms described here, a verifier could rely on the
+demonstration of common values to bind all of the credentials to the holder.
+
+##### Biometrics
+This type of holder binding, instead of relying on demonstrating knowledge of
+some secret value, relies on the evaluation of biometric data. There are a
+number of mechanisms for safely embedding biometric information in a credential
+such that only a person who can confirm the biometric may use the credential. 
+
 ### JSON Schema
 
 The following JSON Schema Draft 7 definition summarizes the


### PR DESCRIPTION
This PR adds a description of various holder bindings to the spec.

More discussion is needed to explore ways to incorporate these holder bindings into the submission requirements or input descriptors of a presentation definition.

fixes #28, fixes #12 

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>