### PR TITLE
added entries for definition and submission

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2053,5 +2053,6 @@ Presentation Submission                      | Values
 ------------------------------|------------
 Claim Name: | `presentation_submission`
 Claim Description: | Presentation Submission
-Change Controller: | DIF Claims & Credentials - Working Group - TBD@email.com
+Change Controller: | DIF Claims & Credentials - Working Group - https://github.com/decentralized-identity/claims-credentials/blob/main/CODEOWNERS
+
 Specification Document(s): | Section 6 of this document

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2033,3 +2033,25 @@ JSONPath                      | Description
     - https://github.com/Stranger6667/jsonschema-rs
 - **Go**
     - https://github.com/xeipuuv/gojsonschema
+
+### IANA Considerations
+
+#### JSON Web Token Claims Registration
+
+This specification registers the Claims defined in Section 5.1 and Section 2 in the IANA JSON Web Token Claims registry defined in [[RFC7519]].
+
+##### Registry Contents
+
+Presentation Definitiion | Values
+------------------------------|------------
+Claim Name: | `presentation_definition`
+Claim Description: | Presentation Definition
+Change Controller: | DIF Claims & Credentials - Working Group - TBD@email.com
+Reference | Section XXX of this document
+
+Presentation Submission                      | Values
+------------------------------|------------
+Claim Name: | `presentation_submission`
+Claim Description: | Presentation Submission
+Change Controller: | DIF Claims & Credentials - Working Group - TBD@email.com
+Specification Document(s): | Section XXX of this document

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2047,7 +2047,7 @@ Presentation Definition | Values
 Claim Name: | `presentation_definition`
 Claim Description: | Presentation Definition
 Change Controller: | DIF Claims & Credentials - Working Group - TBD@email.com
-Reference | Section XXX of this document
+Reference | Section 5 of this document
 
 Presentation Submission                      | Values
 ------------------------------|------------

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2042,7 +2042,7 @@ This specification registers the claims in section [Registry Contents]() in the 
 
 ##### Registry Contents
 
-Presentation Definitiion | Values
+Presentation Definition | Values
 ------------------------------|------------
 Claim Name: | `presentation_definition`
 Claim Description: | Presentation Definition

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2046,7 +2046,8 @@ Presentation Definition | Values
 ------------------------------|------------
 Claim Name: | `presentation_definition`
 Claim Description: | Presentation Definition
-Change Controller: | DIF Claims & Credentials - Working Group - TBD@email.com
+Change Controller: | DIF Claims & Credentials - Working Group - https://github.com/decentralized-identity/claims-credentials/blob/main/CODEOWNERS
+
 Reference | Section 5 of this document
 
 Presentation Submission                      | Values

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2038,7 +2038,7 @@ JSONPath                      | Description
 
 #### JSON Web Token Claims Registration
 
-This specification registers the claims in section [Registry Contents]() in the IANA JSON Web Token Claims registry defined in [[RFC7519]].
+This specification registers the claims in section [Registry Contents]() in the IANA JSON Web Token Claims registry defined in [RFC 751 JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519).
 
 ##### Registry Contents
 
@@ -2047,13 +2047,11 @@ Presentation Definition | Values
 Claim Name: | `presentation_definition`
 Claim Description: | Presentation Definition
 Change Controller: | DIF Claims & Credentials - Working Group - https://github.com/decentralized-identity/claims-credentials/blob/main/CODEOWNERS
-
-Reference | Section 5 of this document
+Specification Document(s): | Section 5 of this document
 
 Presentation Submission                      | Values
 ------------------------------|------------
 Claim Name: | `presentation_submission`
 Claim Description: | Presentation Submission
 Change Controller: | DIF Claims & Credentials - Working Group - https://github.com/decentralized-identity/claims-credentials/blob/main/CODEOWNERS
-
 Specification Document(s): | Section 6 of this document

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2038,7 +2038,7 @@ JSONPath                      | Description
 
 #### JSON Web Token Claims Registration
 
-This specification registers the Claims defined in Section 5.1 and Section 2 in the IANA JSON Web Token Claims registry defined in [[RFC7519]].
+This specification registers the claims in section [Registry Contents]() in the IANA JSON Web Token Claims registry defined in [[RFC7519]].
 
 ##### Registry Contents
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2054,4 +2054,4 @@ Presentation Submission                      | Values
 Claim Name: | `presentation_submission`
 Claim Description: | Presentation Submission
 Change Controller: | DIF Claims & Credentials - Working Group - TBD@email.com
-Specification Document(s): | Section XXX of this document
+Specification Document(s): | Section 6 of this document


### PR DESCRIPTION
@csuwildcat @glcohen @timcappalli  are there any other potentially top level claims that we need to register? Currently, I identified `presentation_definition` and `presentation_submission` but I guess `input_descriptor` and `presentation_requirements` might be top-level too?