### PR TITLE
Clarify predicates

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -901,7 +901,7 @@ values, and an explanation why a certain item or set of data is being requested:
           `predicate` property is present, the `filter` property ****MUST****
           also be present. 
           
-          Note: The inclusion of the `predicate` property indicates that the
+          :::note The inclusion of the `predicate` property indicates that the
           processing entity returns a boolean, rather than a value returned
           from evaluation of the
           [JSONPath](https://goessner.net/articles/JsonPath/) string
@@ -913,11 +913,20 @@ values, and an explanation why a certain item or set of data is being requested:
           returned from evaluation of the
           [JSONPath](https://goessner.net/articles/JsonPath/) string
           expressions in the `path` array.
+          :::
           
           The value of `predicate` ****MUST**** be one of the following strings:
             - `required` - This indicates that the returned value ****MUST****
               be the boolean result of applying the value of the `filter`
               property to the result of evaluating the `path` property.
+              :::note Using a value of `required` for the `predicate` property
+              may severely limit the responses a [[ref:Holder]] may be able to
+              make. Many signature schemes do not support deriving predicates,
+              even those signature schemes which are otherwise ZKP-capable. A
+              [[ref:Verifier]] should be sure they support such schemes, and
+              have high confidence they are also supported by the
+              [[ref:Holder]], before indicating predicate responses are
+              required.:::
             - `preferred` - This indicates that the returned value
               ****SHOULD**** be the boolean result of applying the value of the
               `filter` property to the result of evaluating the `path` property.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -897,7 +897,7 @@ values, and an explanation why a certain item or set of data is being requested:
           used to filter against the values returned from evaluation of the
           [JSONPath](https://goessner.net/articles/JsonPath/) string
           expressions in the `path` array.
-        - The object ****MAY**** contain a `predicate` property. If the
+        - The _fields object_ ****MAY**** contain a `predicate` property. If the
           `predicate` property is present, the `filter` property ****MUST****
           also be present. 
           
@@ -930,7 +930,10 @@ values, and an explanation why a certain item or set of data is being requested:
             - `preferred` - This indicates that the returned value
               ****SHOULD**** be the boolean result of applying the value of the
               `filter` property to the result of evaluating the `path` property.
-
+            
+          If the `predicate` property is not present, a processing entity
+          ****MUST NOT**** return derived predicate values.
+    
           If the `predicate` property is present, the set of JSON Schema
           descriptors which comprise the value of the `filter` property
           ****MUST**** be restricted according to the desired predicate


### PR DESCRIPTION
fixes #174 and fixes #175

Adds language to warn against using `"predicate": "required"` unless you know what you're doing
 Clarifies what to do if `predicate` is absent.