### PR TITLE
Clarify Presentation Definition ID

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -244,8 +244,8 @@ The following properties are for use at the top-level of a
 be ignored:
 
 - `id` - The [[ref:Presentation Definition]] ****MUST**** contain an `id`
-  property. The value of this property ****SHOULD**** be a string that provides
-  a unique ID for the desired context. For example, a
+  property. The value of this property ****MUST**** be a string. The string
+  ****SHOULD**** provide a unique ID for the desired context. For example, a
   [UUID](https://tools.ietf.org/html/rfc4122) such as `32f54163-7166-48f1-93d8-f
   f217bdb0653` could provide an ID that is unique in a global context, while a
   simple string such as `my_presentation_definition_1` could be suitably unique

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -244,8 +244,12 @@ The following properties are for use at the top-level of a
 be ignored:
 
 - `id` - The [[ref:Presentation Definition]] ****MUST**** contain an `id`
-  property. The value of this property ****MUST**** be a unique identifier, such
-  as a [UUID](https://tools.ietf.org/html/rfc4122).
+  property. The value of this property ****SHOULD**** be a string that provides
+  a unique ID for the desired context. For example, a
+  [UUID](https://tools.ietf.org/html/rfc4122) such as `32f54163-7166-48f1-93d8-f
+  f217bdb0653` could provide an ID that is unique in a global context, while a
+  simple string such as `my_presentation_definition_1` could be suitably unique
+  in a local context.
 - `input_descriptors` - The [[ref:Presentation Definition]]  ****MUST****
   contain an `input_descriptors` property. Its value ****MUST**** be an array of
   [[ref:Input Descriptor Objects]], the composition of which are described in


### PR DESCRIPTION
This PR modifies the normative description of `presentation_definition.id` to say that the value must be a string that should be unique within a certain context.
fixes #232