### PR TITLE
Reinstate v1 test files

### DIFF
--- a/spec/v1.0.0/spec.md
+++ b/spec/v1.0.0/spec.md
@@ -59,7 +59,7 @@ these data formats within their flows.
 
 ## Status of This Document
 
-Presentation Exchange v1.0 is a _DIF Ratified Specification_ that has been developed within
+Presentation Exchange v1.0 is a _DIF Ratified_ specification that has been developed within
 the Decentralized Identity Foundation (DIF). It incorporates requirements and
 learnings from related work of many active industry players into a shared
 specification that meets the collective needs of the community.
@@ -194,7 +194,7 @@ requirement.
 
 ::: example Presentation Definition - Minimal Example
 ```json
-[[insert ./test/presentation-definition/minimal_example.json ]]
+[[insert: ./test/v1.0.0/presentation-definition/minimal_example.json ]]
 ```
 
 </section>
@@ -203,7 +203,7 @@ requirement.
 
 ::: example Presentation Definition - Basic Example
 ```json
-[[insert ./test/presentation-definition/basic_example.json ]]
+[[insert: ./test/v1.0.0/presentation-definition/basic_example.json ]]
 ```
 
 </section>
@@ -212,7 +212,7 @@ requirement.
 
 ::: example Presentation Definition - Single Group Example
 ```json
-[[insert: ./test/presentation-definition/single_group_example.json]]
+[[insert: ./test/v1.0.0/presentation-definition/single_group_example.json]]
 ```
 
 </section>
@@ -221,7 +221,7 @@ requirement.
 
 ::: example Presentation Definition - Multi-Group Example
 ```json
-[[insert: ./test/presentation-definition/multi_group_example.json]]
+[[insert: ./test/v1.0.0/presentation-definition/multi_group_example.json]]
 ```
 :::
 
@@ -270,7 +270,7 @@ be ignored:
       For example:
 
 ```json
-[[insert: ./test/presentation-definition/format_example.json]]
+[[insert: ./test/v1.0.0/presentation-definition/format_example.json]]
 ```
 
 - `submission_requirements` - The [[ref:Presentation Definition]] ****MAY****
@@ -303,7 +303,7 @@ values, and an explanation why a certain item or set of data is being requested:
 
 ::: example
 ```json
-[[insert: ./test/presentation-definition/input_descriptors_example.json]]
+[[insert: ./test/v1.0.0/presentation-definition/input_descriptors_example.json]]
 ```
 :::
 
@@ -313,7 +313,7 @@ values, and an explanation why a certain item or set of data is being requested:
 
 ::: example
 ```json
-[[insert: ./test/presentation-definition/input_descriptor_id_tokens_example.json]]
+[[insert: ./test/v1.0.0/presentation-definition/input_descriptor_id_tokens_example.json]]
 ```
 
 </section>
@@ -671,7 +671,7 @@ all input_descriptors ****MUST**** be grouped. Any unused
 
 ::: example Submission Requirement
 ```json 12
-[[insert: ./test/submission-requirements/example.json ]]
+[[insert: ./test/v1.0.0/submission-requirements/example.json ]]
 ```
 :::
 
@@ -726,7 +726,7 @@ For an `all` rule [[ref:Submission Requirement Object]]:
 
 ::: example Submission Requirement, all, group
 ```json
-[[insert: ./test/submission-requirements/all_example.json]]
+[[insert: ./test/v1.0.0/submission-requirements/all_example.json]]
 ```
 :::
 
@@ -766,13 +766,13 @@ with a matching `group` string. In the first example that follows, the
 
 ::: example Submission Requirement, pick, group
 ```json
-[[insert: ./test/submission-requirements/pick_1_example.json]]
+[[insert: ./test/v1.0.0/submission-requirements/pick_1_example.json]]
 ```
 :::
 
 ::: example Submission Requirement, pick, min/max
 ```json
-[[insert: ./test/submission-requirements/pick_2_example.json]]
+[[insert: ./test/v1.0.0/submission-requirements/pick_2_example.json]]
 ```
 :::
 
@@ -785,7 +785,7 @@ from group `"A"` or two members from group `"B"`:
 
 ::: example Submission Requirement, pick, nested
 ```json
-[[insert: ./test/submission-requirements/pick_3_example.json]]
+[[insert: ./test/v1.0.0/submission-requirements/pick_3_example.json]]
 ```
 :::
 
@@ -794,7 +794,7 @@ The following JSON Schema Draft 7 definition summarizes many of the
 format-related rules above:
 
 ```json
-[[insert: ./test/submission-requirements/schema.json]]
+[[insert: ./test/v1.0.0/submission-requirements/schema.json]]
 ```
 
 #### Property Values and Evaluation
@@ -941,7 +941,7 @@ requisite information to resolve the status of a [[ref:Claim]].
 
 ::: example Drivers License Expiration
 ```json
-[[insert: ./test/presentation-definition/VC_expiration_example.json]]
+[[insert: ./test/v1.0.0/presentation-definition/VC_expiration_example.json]]
 ```
 :::
 
@@ -951,7 +951,7 @@ requisite information to resolve the status of a [[ref:Claim]].
 
 ::: example Drivers License Revocation
 ```json
-[[insert: ./test/presentation-definition/VC_revocation_example.json]]
+[[insert: ./test/v1.0.0/presentation-definition/VC_revocation_example.json]]
 ```
 :::
 </section>
@@ -1022,7 +1022,7 @@ The following JSON Schema Draft 7 definition summarizes the
 format-related rules above:
 
 ```json
-[[insert: ./test/presentation-definition/schema.json]]
+[[insert: ./test/v1.0.0/presentation-definition/schema.json]]
 ```
 
 ### Presentation Request
@@ -1131,7 +1131,7 @@ composed and embedded as follows:
 ****Example Nested Submission****
 
 ```json
-[[insert: ./test/presentation-submission/nested_submission_example.json]]
+[[insert: ./test/v1.0.0/presentation-submission/nested_submission_example.json]]
 ```
 
 When the `path_nested` property is present in a [[ref:Presentation Submission]]
@@ -1216,7 +1216,7 @@ CHAPI      | `$.data`
 The following JSON Schema Draft 7 definition summarizes the rules above:
 
 ```json
-[[insert: ./test/presentation-submission/schema.json]]
+[[insert: ./test/v1.0.0/presentation-submission/schema.json]]
 ```
 
 ## Claim Format Designations
@@ -1401,7 +1401,7 @@ JSONPath                      | Description
 
 ::: example Presentation Submission - Verifiable Presentation
 ```json
-[[insert: ./test/presentation-submission/appendix_VP_example.json]]
+[[insert: ./test/v1.0.0/presentation-submission/appendix_VP_example.json]]
 ```
 :::
 
@@ -1411,7 +1411,7 @@ JSONPath                      | Description
 
 ::: example Presentation Submission with OIDC JWT
 ```json
-[[insert: ./test/presentation-submission/appendix_OIDC_example.json]]
+[[insert: ./test/v1.0.0/presentation-submission/appendix_OIDC_example.json]]
 ```
 :::
 
@@ -1421,7 +1421,7 @@ JSONPath                      | Description
 
 ::: example Presentation Submission using CHAPI
 ```json
-[[insert: ./test/presentation-submission/appendix_CHAPI_example.json]]
+[[insert: ./test/v1.0.0/presentation-submission/appendix_CHAPI_example.json]]
 ```
 
 </section>
@@ -1430,7 +1430,7 @@ JSONPath                      | Description
 
 ::: example Presentation Submission using DIDComm
 ```json
-[[insert: ./test/presentation-submission/appendix_DIDComm_example.json]]
+[[insert: ./test/v1.0.0/presentation-submission/appendix_DIDComm_example.json]]
 ```
 :::
 

--- a/test/v1.0.0/presentation-definition/VC_expiration_example.json
+++ b/test/v1.0.0/presentation-definition/VC_expiration_example.json
@@ -1,0 +1,23 @@
+{
+  "id": "drivers_license_information",
+  "name": "Verify Valid License",
+  "purpose": "We need you to show that your driver's license will be valid through December of this year.",
+  "schema": [
+    {
+      "uri": "https://yourwatchful.gov/drivers-license-schema.json",
+      "required": true
+    }
+  ],
+  "constraints": {
+    "fields": [
+      {
+        "path": ["$.expirationDate"],
+        "filter": {
+          "type": "string",
+          "format": "date-time",
+          "minimum": "2020-12-31T23:59:59.000Z"
+        }
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-definition/VC_revocation_example.json
+++ b/test/v1.0.0/presentation-definition/VC_revocation_example.json
@@ -1,0 +1,17 @@
+{
+  "id": "drivers_license_information",
+  "name": "Verify Valid License",
+  "purpose": "We need to know that your license has not been revoked.",
+  "schema": [
+    {
+      "uri": "https://yourwatchful.gov/drivers-license-schema.json"
+    }
+  ],
+  "constraints": {
+    "fields": [
+      {
+        "path": ["$.credentialStatus"]
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-definition/basic_example.json
+++ b/test/v1.0.0/presentation-definition/basic_example.json
@@ -1,0 +1,55 @@
+{
+  "comment": "Note: VP, OIDC, DIDComm, or CHAPI outer wrapper would be here.",
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "input_descriptors": [
+      {
+        "id": "bankaccount_input",
+        "name": "Full Bank Account Routing Information",
+        "purpose": "We can only remit payment to a currently-valid bank account, submitted as an ABA RTN + Acct # or IBAN.",
+        "schema": [{
+            "uri": "https://bank-standards.example.com/fullaccountroute.json"
+        }],
+        "constraints": {
+          "limit_disclosure": "required",
+          "fields": [
+            {
+              "path": [
+                  "$.issuer", 
+                  "$.vc.issuer", 
+                  "$.iss"
+              ],
+              "purpose": "We can only verify bank accounts if they are attested by a trusted bank, auditor, or regulatory authority.",
+              "filter": {
+                "type": "string",
+                "pattern": "did:example:123|did:example:456"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "us_passport_input",
+        "name": "US Passport",
+        "schema": [
+          {
+            "uri": "hub://did:foo:123/Collections/schema.us.gov/passport.json"
+          }
+        ],
+        "constraints": {
+          "fields": [
+            {
+              "path": ["$.credentialSubject.birth_date", "$.vc.credentialSubject.birth_date", "$.birth_date"],
+              "filter": {
+                "type": "string",
+                "format": "date",
+                "minimum": "1999-05-16"
+              }
+            }
+          ]
+        }
+
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-definition/format_example.json
+++ b/test/v1.0.0/presentation-definition/format_example.json
@@ -1,0 +1,31 @@
+{
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "input_descriptors": [],
+    "format": {
+      "jwt": {
+        "alg": ["EdDSA", "ES256K", "ES384"]
+      },
+      "jwt_vc": {
+        "alg": ["ES256K", "ES384"]
+      },
+      "jwt_vp": {
+        "alg": ["EdDSA", "ES256K"]
+      },
+      "ldp_vc": {
+        "proof_type": [
+          "JsonWebSignature2020",
+          "Ed25519Signature2018",
+          "EcdsaSecp256k1Signature2019",
+          "RsaSignature2018"
+        ]
+      },
+      "ldp_vp": {
+        "proof_type": ["Ed25519Signature2018"]
+      },
+      "ldp": {
+        "proof_type": ["RsaSignature2018"]
+      }
+    }
+  }
+}

--- a/test/v1.0.0/presentation-definition/input_descriptor_id_tokens_example.json
+++ b/test/v1.0.0/presentation-definition/input_descriptor_id_tokens_example.json
@@ -1,0 +1,30 @@
+{
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "input_descriptors": [
+      {
+        "id": "employment_input_xyz_gov",
+        "group": ["B"],
+        "schema": [
+          {
+            "uri": "https://login.idp.com/xyz.gov/.well-known/openid-configuration",
+            "required": true
+          }
+        ],
+        "name": "Verify XYZ Government Employment",
+        "purpose": "Verifying current employment at XYZ Government agency as proxy for permission to access this resource",
+        "constraints": {
+          "fields": [
+            {
+              "path": ["$.status"],
+              "filter": {
+                "type": "string",
+                "pattern": "active"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-definition/input_descriptors_example.json
+++ b/test/v1.0.0/presentation-definition/input_descriptors_example.json
@@ -1,0 +1,63 @@
+{
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "input_descriptors": [
+      {
+        "id": "banking_input_1",
+        "name": "Bank Account Information",
+        "purpose": "We can only remit payment to a currently-valid bank account.",
+        "group": [
+          "A"
+        ],
+        "schema": [
+          {
+            "uri": "https://bank-schemas.org/1.0.0/accounts.json"
+          },
+          {
+            "uri": "https://bank-schemas.org/2.0.0/accounts.json"
+          }
+        ],
+        "constraints": {
+          "fields": [
+            {
+              "path": [
+                "$.issuer",
+                "$.vc.issuer",
+                "$.iss"
+              ],
+              "purpose": "We can only verify bank accounts if they are attested by a trusted bank, auditor or regulatory authority.",
+              "filter": {
+                "type": "string",
+                "pattern": "did:example:123|did:example:456"
+              }
+            },
+            {
+              "path": [
+                "$.credentialSubject.account[*].id",
+                "$.vc.credentialSubject.account[*].id",
+                "$.account[*].id"
+              ],
+              "purpose": "We can only remit payment to a currently-valid bank account in the US, France, or Germany, submitted as an ABA Acct # or IBAN.",
+              "filter": {
+                "type": "string",
+                "pattern": "^[0-9]{10-12}|^(DE|FR)[0-9]{2}\\s?([0-9a-zA-Z]{4}\\s?){4}[0-9a-zA-Z]{2}$"
+              }
+            },
+            {
+              "path": [
+                "$.credentialSubject.account[*].route",
+                "$.vc.credentialSubject.account[*].route",
+                "$.account[*].route"
+              ],
+              "purpose": "We can only remit payment to a currently-valid account at a US, Japanese, or German federally-accredited bank, submitted as an ABA RTN or SWIFT code.",
+              "filter": {
+                "type": "string",
+                "pattern": "^[0-9]{9}|^([a-zA-Z]){4}([a-zA-Z]){2}([0-9a-zA-Z]){2}([0-9a-zA-Z]{3})?$"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-definition/minimal_example.json
+++ b/test/v1.0.0/presentation-definition/minimal_example.json
@@ -1,0 +1,16 @@
+{
+  "comment": "Note: VP, OIDC, DIDComm, or CHAPI outer wrapper would be here.",
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "input_descriptors": [
+      {
+        "id": "wa_driver_license",
+        "name": "Washington State Business License",
+        "purpose": "We can only allow licensed Washington State business representatives into the WA Business Conference",
+        "schema": [{
+            "uri": "https://licenses.example.com/business-license.json"
+        }]
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-definition/multi_group_example.json
+++ b/test/v1.0.0/presentation-definition/multi_group_example.json
@@ -1,0 +1,218 @@
+{
+  "comment": "VP, OIDC, DIDComm, or CHAPI outer wrapper here",
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "submission_requirements": [
+      {
+        "name": "Banking Information",
+        "purpose": "We can only remit payment to a currently-valid bank account in the US, Germany or France.",
+        "rule": "pick",
+        "count": 1,
+        "from": "A"
+      },
+      {
+        "name": "Employment Information",
+        "purpose": "We are only verifying one current employment relationship, not any other information about employment.",
+        "rule": "all",
+        "from": "B"
+      },
+      {
+        "name": "Eligibility to Drive on US Roads",
+        "purpose": "We need to verify eligibility to drive on US roads via US or EU driver's license, but no biometric or identifying information contained there.",
+        "rule": "pick",
+        "count": 1,
+        "from": "C"
+      }
+    ],
+    "input_descriptors": [
+      {
+        "id": "banking_input_1",
+        "name": "Bank Account Information",
+        "purpose": "Bank Account required to remit payment.",
+        "group": ["A"],
+        "schema": [
+          {
+            "uri": "https://bank-standards.example.com#accounts",
+            "required": true
+          },
+          {
+            "uri": "https://bank-standards.example.com#investments",
+            "required": true
+          }
+        ],
+        "constraints": {
+          "limit_disclosure": "required",
+          "fields": [
+            {
+              "path": ["$.issuer", "$.vc.issuer", "$.iss"],
+              "purpose": "We can only verify bank accounts if they are attested by a trusted bank, auditor or regulatory authority.",
+              "filter": {
+                "type": "string",
+                "pattern": "did:example:123|did:example:456"
+              }
+            },
+            {
+              "path": [
+                "$.credentialSubject.account[*].account_number", 
+                "$.vc.credentialSubject.account[*].account_number", 
+                "$.account[*].account_number"
+              ],
+              "purpose": "We can only remit payment to a currently-valid bank account in the US, France, or Germany, submitted as an ABA Acct # or IBAN.",
+              "filter": {
+                "type": "string",
+                "pattern": "^[0-9]{10-12}|^(DE|FR)[0-9]{2}\\s?([0-9a-zA-Z]{4}\\s?){4}[0-9a-zA-Z]{2}$"
+              }
+            },
+            {
+              "path": ["$.credentialSubject.portfolio_value", "$.vc.credentialSubject.portfolio_value", "$.portfolio_value"],
+              "purpose": "A current portfolio value of at least one million dollars is required to insure your application",
+              "filter": {
+                "type": "number",
+                "minimum": 1000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "banking_input_2",
+        "name": "Bank Account Information",
+        "purpose": "We can only remit payment to a currently-valid bank account.",
+        "group": ["A"],
+        "schema": [
+          {
+            "uri": "https://bank-schemas.org/1.0.0/accounts.json"
+          },
+          {
+            "uri": "https://bank-schemas.org/2.0.0/accounts.json"
+          }
+        ],
+        "constraints": {
+          "fields": [
+            {
+              "path": [
+                "$.issuer", 
+                "$.vc.issuer", 
+                "$.iss"
+              ],
+              "purpose": "We can only verify bank accounts if they are attested by a trusted bank, auditor or regulatory authority.",
+              "filter": {
+                "type": "string",
+                "pattern": "did:example:123|did:example:456"
+              }
+            },
+            { 
+              "path": [
+                "$.credentialSubject.account[*].id", 
+                "$.vc.credentialSubject.account[*].id", 
+                "$.account[*].id"
+              ],
+              "purpose": "We can only remit payment to a currently-valid bank account in the US, France, or Germany, submitted as an ABA Acct # or IBAN.",
+              "filter": {
+                "type": "string",
+                "pattern": "^[0-9]{10-12}|^(DE|FR)[0-9]{2}\\s?([0-9a-zA-Z]{4}\\s?){4}[0-9a-zA-Z]{2}$"
+              }
+            },
+            {
+              "path": [
+                "$.credentialSubject.account[*].route", 
+                "$.vc.credentialSubject.account[*].route", 
+                "$.account[*].route"
+              ],
+              "purpose": "We can only remit payment to a currently-valid account at a US, Japanese, or German federally-accredited bank, submitted as an ABA RTN or SWIFT code.",
+              "filter": {
+                "type": "string",
+                "pattern": "^[0-9]{9}|^([a-zA-Z]){4}([a-zA-Z]){2}([0-9a-zA-Z]){2}([0-9a-zA-Z]{3})?$"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "employment_input",
+        "name": "Employment History",
+        "purpose": "We are only verifying one current employment relationship, not any other information about employment.",
+        "group": ["B"],
+        "schema": [
+          {
+            "uri": "https://business-standards.org/schemas/employment-history.json"
+          }
+        ],
+        "constraints": {
+          "limit_disclosure": "required",
+          "fields": [
+            {
+              "path": ["$.jobs[*].active"],
+              "filter": {
+                "type": "boolean",
+                "pattern": "true"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "drivers_license_input_1",
+        "name": "EU Driver's License",
+        "group": ["C"],
+        "schema": [
+          {
+            "uri": "https://schema.eu/claims/DriversLicense.json"
+          }
+        ],
+        "constraints": {
+          "fields": [
+            {
+              "path": ["$.issuer", "$.vc.issuer", "$.iss"],
+              "purpose": "We can only accept digital driver's licenses issued by national authorities of EU member states or trusted notarial auditors.",
+              "filter": {
+                "type": "string",
+                "pattern": "did:example:gov1|did:example:gov2"
+              }
+            },
+            {
+              "path": ["$.credentialSubject.dob", "$.vc.credentialSubject.dob", "$.dob"],
+              "purpose": "We must confirm that the driver was at least 21 years old on April 16, 2020.",
+              "filter": {
+                "type": "string",
+                "format": "date",
+                "maximum": "1999-05-16"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "drivers_license_input_2",
+        "name": "Driver's License from one of 50 US States",
+        "group": ["C"],
+        "schema": [
+          {
+            "uri": "hub://did:foo:123/Collections/schema.us.gov/american_drivers_license.json"
+          }
+        ],
+        "constraints": {
+          "fields": [
+            {
+              "path": ["$.issuer", "$.vc.issuer", "$.iss"],
+              "purpose": "We can only accept digital driver's licenses issued by the 50 US states' automative affairs agencies.",
+              "filter": {
+                "type": "string",
+                "pattern": "did:example:gov1|did:web:dmv.ca.gov|did:example:oregonDMV"
+              }
+            },
+            {
+              "path": ["$.credentialSubject.birth_date", "$.vc.credentialSubject.birth_date", "$.birth_date"],
+              "purpose": "We must confirm that the driver was at least 21 years old on April 16, 2020.",
+              "filter": {
+                "type": "string",
+                "format": "date",
+                "maximum": "1999-05-16"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-definition/schema.json
+++ b/test/v1.0.0/presentation-definition/schema.json
@@ -1,0 +1,277 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Presentation Definition",
+  "definitions": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "uri": { "type": "string" },
+        "required": { "type": "boolean" }
+      },
+      "required": ["uri"],
+      "additionalProperties": false
+    },
+    "filter": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "format": { "type": "string" },
+        "pattern": { "type": "string" },
+        "minimum": { "type": ["number", "string"] },
+        "minLength": { "type": "integer" },
+        "maxLength": { "type": "integer" },
+        "exclusiveMinimum": { "type": ["number", "string"] },
+        "exclusiveMaximum": { "type": ["number", "string"] },
+        "maximum": { "type": ["number", "string"] },
+        "const": { "type": ["number", "string"] },
+        "enum": {
+          "type": "array",
+          "items": { "type": ["number", "string"] }
+        },
+        "not": {
+          "type": "object",
+          "minProperties": 1
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "format": {
+      "type": "object",
+      "patternProperties": {
+        "^jwt$|^jwt_vc$|^jwt_vp$": {
+          "type": "object",
+          "properties": {
+            "alg": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          },
+          "required": ["alg"],
+          "additionalProperties": false
+        },
+        "^ldp_vc$|^ldp_vp$|^ldp$": {
+          "type": "object",
+          "properties": {
+            "proof_type": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          },
+          "required": ["proof_type"],
+          "additionalProperties": false
+        },
+        "additionalProperties": false
+      },
+      "additionalProperties": false
+    },
+    "submission_requirements": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "name": { "type": "string" },
+            "purpose": { "type": "string" },
+            "rule": {
+              "type": "string",
+              "enum": ["all", "pick"]
+            },
+            "count": { "type": "integer", "minimum": 1 },
+            "min": { "type": "integer", "minimum": 0 },
+            "max": { "type": "integer", "minimum": 0 },
+            "from": { "type": "string" }
+          },
+          "required": ["rule", "from"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "name": { "type": "string" },
+            "purpose": { "type": "string" },
+            "rule": {
+              "type": "string",
+              "enum": ["all", "pick"]
+            },
+            "count": { "type": "integer", "minimum": 1 },
+            "min": { "type": "integer", "minimum": 0 },
+            "max": { "type": "integer", "minimum": 0 },
+            "from_nested": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/submission_requirements"
+              }
+            }
+          },
+          "required": ["rule", "from_nested"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "input_descriptors": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "purpose": { "type": "string" },
+        "group": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "schema": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/schema" }
+        },
+        "constraints": {
+          "type": "object",
+          "properties": {
+            "limit_disclosure": {
+              "type": "string",
+              "enum": ["required", "preferred"]
+            },
+            "statuses": {
+              "type": "object",
+              "properties": {
+                "active": {
+                  "type": "object",
+                  "properties": {
+                    "directive": {
+                      "type": "string",
+                      "enum": ["required", "allowed", "disallowed"]
+                    }
+                  }
+                },
+                "suspended": {
+                  "type": "object",
+                  "properties": {
+                    "directive": {
+                      "type": "string",
+                      "enum": ["required", "allowed", "disallowed"]
+                    }
+                  }
+                },
+                "revoked": {
+                  "type": "object",
+                  "properties": {
+                    "directive": {
+                      "type": "string",
+                      "enum": ["required", "allowed", "disallowed"]
+                    }
+                  }
+                }
+              }
+            },
+            "fields": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/field" }
+            },
+            "subject_is_issuer": {
+              "type": "string",
+              "enum": ["required", "preferred"]
+            },
+            "is_holder": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties":  {
+                  "field_id": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "directive": {
+                    "type": "string",
+                    "enum": ["required", "preferred"]
+                  }
+                },
+                "required": ["field_id", "directive"],
+                "additionalProperties": false
+              }
+            },
+            "same_subject": {
+              "type":  "array",
+              "items": {
+                "type": "object",
+                "properties":  {
+                  "field_id": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "directive": {
+                    "type": "string",
+                    "enum": ["required", "preferred"]
+                  }
+                },
+                "required": ["field_id", "directive"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["id", "schema"],
+      "additionalProperties": false
+    },
+    "field": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "id": { "type": "string" },
+            "path": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "purpose": { "type": "string" },
+            "filter": { "$ref": "#/definitions/filter" }
+          },
+          "required": ["path"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "id": { "type": "string" },
+            "path": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "purpose": { "type": "string" },
+            "filter": { "$ref": "#/definitions/filter" },
+            "predicate": {
+              "type": "string",
+              "enum": ["required", "preferred"]
+            }
+          },
+          "required": ["path", "filter", "predicate"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "presentation_definition": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "purpose": { "type": "string" },
+        "format": { "$ref": "#/definitions/format"},
+        "submission_requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/submission_requirements"
+          }
+        },
+        "input_descriptors": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/input_descriptors" }
+        }
+      },
+      "required": ["id", "input_descriptors"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/test/v1.0.0/presentation-definition/single_group_example.json
+++ b/test/v1.0.0/presentation-definition/single_group_example.json
@@ -1,0 +1,66 @@
+{
+  "comment": "VP, OIDC, DIDComm, or CHAPI outer wrapper here",
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "submission_requirements": [{
+      "name": "Citizenship Information",
+      "rule": "pick",
+      "count": 1,
+      "from": "A"
+    }],
+    "input_descriptors": [
+      {
+        "id": "citizenship_input_1",
+        "name": "EU Driver's License",
+        "group": ["A"],
+        "schema": [
+          {
+            "uri": "https://eu.com/claims/DriversLicense.json"
+          }
+        ],
+        "constraints": {
+          "fields": [
+            {
+              "path": ["$.issuer", "$.vc.issuer", "$.iss"],
+              "purpose": "We can only accept digital driver's licenses issued by national authorities of member states or trusted notarial auditors.",
+              "filter": {
+                "type": "string",
+                "pattern": "did:example:gov1|did:example:gov2"
+              }
+            },
+            {
+              "path": ["$.credentialSubject.dob", "$.vc.credentialSubject.dob", "$.dob"],
+              "filter": {
+                "type": "string",
+                "format": "date",
+                "maximum": "1999-06-15"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "citizenship_input_2",
+        "name": "US Passport",
+        "group": ["A"],
+        "schema": [
+          {
+            "uri": "hub://did:foo:123/Collections/schema.us.gov/passport.json"
+          }
+        ],
+        "constraints": {
+          "fields": [
+            {
+              "path": ["$.credentialSubject.birth_date", "$.vc.credentialSubject.birth_date", "$.birth_date"],
+              "filter": {
+                "type": "string",
+                "format": "date",
+                "maximum": "1999-05-16"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-definition/test.js
+++ b/test/v1.0.0/presentation-definition/test.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const assert = require('assert');
+const ajv = require('ajv');
+
+
+describe('Presentation Definition', function () {
+  describe('JSON Schema', function () {
+    it('should validate the basic example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/basic_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the single group example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/single_group_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the multi group example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/multi_group_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the format example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/format_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the input description sample example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/input_descriptors_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the input description id tokens example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/input_descriptor_id_tokens_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the VC expiration example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/VC_expiration_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the VC revocation example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/VC_revocation_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+  });
+});

--- a/test/v1.0.0/presentation-submission/appendix_CHAPI_example.json
+++ b/test/v1.0.0/presentation-submission/appendix_CHAPI_example.json
@@ -1,0 +1,8 @@
+{
+    "type": "web",
+    "dataType": "VerifiablePresentation",
+    "data": {
+      "comment": "Presentation Submission goes here"
+    }
+  }
+  

--- a/test/v1.0.0/presentation-submission/appendix_DIDComm_example.json
+++ b/test/v1.0.0/presentation-submission/appendix_DIDComm_example.json
@@ -1,0 +1,18 @@
+{
+    "@type": "https://didcomm.org/present-proof/%VER/presentation",
+    "@id": "f1ca8245-ab2d-4d9c-8d7d-94bf310314ef",
+    "comment": "some comment",
+    "formats" : [{
+        "attach_id" : "2a3f1c4c-623c-44e6-b159-179048c51260",
+        "format" : "dif/presentation-exchange/submission@v1.0"
+    }],
+    "presentations~attach": [{
+        "@id": "2a3f1c4c-623c-44e6-b159-179048c51260",
+        "mime-type": "application/ld+json",
+        "data": {
+            "json": {
+              "comment": "Presentation Submission goes here"
+            }
+        }
+    }]
+}

--- a/test/v1.0.0/presentation-submission/appendix_OIDC_example.json
+++ b/test/v1.0.0/presentation-submission/appendix_OIDC_example.json
@@ -1,0 +1,81 @@
+{
+  "iss": "https://self-issued.me",
+  "sub": "248289761001",
+  "preferred_username": "superman445",
+  "presentation_submission": {
+    "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+    "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "descriptor_map": [
+      {
+        "id": "banking_input_2",
+        "format": "jwt",
+        "path": "$._claim_sources.banking_input_2.JWT"
+      },
+      {
+        "id": "employment_input",
+        "format": "jwt_vc",
+        "path": "$._claim_sources.employment_input.VC_JWT"
+      },
+      {
+        "id": "citizenship_input_1",
+        "format": "ldp_vc",
+        "path": "$._claim_sources.citizenship_input_1.VC"
+      }
+    ]
+  },
+  "_claim_names": {
+    "verified_claims": [
+      "banking_input_2",
+      "employment_input",
+      "citizenship_input_1"
+    ]
+  },
+  "_claim_sources": {
+    "banking_input_2": {
+      "JWT": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NlcnZlci5vdGhlcm9wLmNvbSIsInN1YiI6ImU4MTQ4NjAzLTg5MzQtNDI0NS04MjViLWMxMDhiOGI2Yjk0NSIsInZlcmlmaWVkX2NsYWltcyI6eyJ2ZXJpZmljYXRpb24iOnsidHJ1c3RfZnJhbWV3b3JrIjoiaWFsX2V4YW1wbGVfZ29sZCJ9LCJjbGFpbXMiOnsiZ2l2ZW5fbmFtZSI6Ik1heCIsImZhbWlseV9uYW1lIjoiTWVpZXIiLCJiaXJ0aGRhdGUiOiIxOTU2LTAxLTI4In19fQ.FArlPUtUVn95HCExePlWJQ6ctVfVpQyeSbe3xkH9MH1QJjnk5GVbBW0qe1b7R3lE-8iVv__0mhRTUI5lcFhLjoGjDS8zgWSarVsEEjwBK7WD3r9cEw6ZAhfEkhHL9eqAaED2rhhDbHD5dZWXkJCuXIcn65g6rryiBanxlXK0ZmcK4fD9HV9MFduk0LRG_p4yocMaFvVkqawat5NV9QQ3ij7UBr3G7A4FojcKEkoJKScdGoozir8m5XD83Sn45_79nCcgWSnCX2QTukL8NywIItu_K48cjHiAGXXSzydDm_ccGCe0sY-Ai2-iFFuQo2PtfuK2SqPPmAZJxEFrFoLY4g"
+    },
+    "employment_input": {
+      "VC": {
+        "@context": "https://www.w3.org/2018/credentials/v1",
+        "id": "https://business-standards.org/schemas/employment-history.json",
+        "type": ["VerifiableCredential", "GenericEmploymentCredential"],
+        "issuer": "did:foo:123",
+        "issuanceDate": "2010-01-01T19:73:24Z",
+        "credentialSubject": {
+          "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+          "active": true
+        },
+        "proof": {
+          "type": "EcdsaSecp256k1VerificationKey2019",
+          "created": "2017-06-18T21:19:10Z",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": "https://example.edu/issuers/keys/1",
+          "jws": "..."
+        }
+      }
+    },
+    "citizenship_input_1": {
+      "VC": {
+        "@context": "https://www.w3.org/2018/credentials/v1",
+        "id": "https://eu.com/claims/DriversLicense",
+        "type": ["EUDriversLicense"],
+        "issuer": "did:foo:123",
+        "issuanceDate": "2010-01-01T19:73:24Z",
+        "credentialSubject": {
+          "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+          "license": {
+            "number": "34DGE352",
+            "dob": "07/13/80"
+          }
+        },
+        "proof": {
+          "type": "EcdsaSecp256k1VerificationKey2019",
+          "created": "2017-06-18T21:19:10Z",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": "https://example.edu/issuers/keys/1",
+          "jws": "..."
+        }
+      }
+    }
+  }
+}

--- a/test/v1.0.0/presentation-submission/appendix_VP_example.json
+++ b/test/v1.0.0/presentation-submission/appendix_VP_example.json
@@ -1,0 +1,104 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://identity.foundation/presentation-exchange/submission/v1"
+  ],
+  "type": [
+    "VerifiablePresentation",
+    "PresentationSubmission"
+  ],
+  "presentation_submission": {
+    "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+    "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "descriptor_map": [
+      {
+        "id": "banking_input_2",
+        "format": "jwt_vc",
+        "path": "$.verifiableCredential[0]"
+      },
+      {
+        "id": "employment_input",
+        "format": "ldp_vc",
+        "path": "$.verifiableCredential[1]"
+      },
+      {
+        "id": "citizenship_input_1",
+        "format": "ldp_vc",
+        "path": "$.verifiableCredential[2]"
+      }
+    ]
+  },
+  "verifiableCredential": [
+    {
+      "comment": "IN REALWORLD VPs, THIS WILL BE A BIG UGLY OBJECT INSTEAD OF THE DECODED JWT PAYLOAD THAT FOLLOWS",
+      "vc": {
+        "@context": "https://www.w3.org/2018/credentials/v1",
+        "id": "https://eu.com/claims/DriversLicense",
+        "type": ["EUDriversLicense"],
+        "issuer": "did:example:123",
+        "issuanceDate": "2010-01-01T19:73:24Z",
+        "credentialSubject": {
+          "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+          "accounts": [
+            {
+              "id": "1234567890",
+              "route": "DE-9876543210"
+            },
+            {
+              "id": "2457913570",
+              "route": "DE-0753197542"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "@context": "https://www.w3.org/2018/credentials/v1",
+      "id": "https://business-standards.org/schemas/employment-history.json",
+      "type": ["VerifiableCredential", "GenericEmploymentCredential"],
+      "issuer": "did:foo:123",
+      "issuanceDate": "2010-01-01T19:73:24Z",
+      "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "active": true
+      },
+      "proof": {
+        "type": "EcdsaSecp256k1VerificationKey2019",
+        "created": "2017-06-18T21:19:10Z",
+        "proofPurpose": "assertionMethod",
+        "verificationMethod": "https://example.edu/issuers/keys/1",
+        "jws": "..."
+      }
+    },
+    {
+      "@context": "https://www.w3.org/2018/credentials/v1",
+      "id": "https://eu.com/claims/DriversLicense",
+      "type": ["EUDriversLicense"],
+      "issuer": "did:foo:123",
+      "issuanceDate": "2010-01-01T19:73:24Z",
+      "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "license": {
+          "number": "34DGE352",
+          "dob": "07/13/80"
+        }
+      },
+      "proof": {
+        "type": "RsaSignature2018",
+        "created": "2017-06-18T21:19:10Z",
+        "proofPurpose": "assertionMethod",
+        "verificationMethod": "https://example.edu/issuers/keys/1",
+        "jws": "..."
+      }
+    }
+  ],
+  "proof": {
+    "type": "RsaSignature2018",
+    "created": "2018-09-14T21:19:10Z",
+    "proofPurpose": "authentication",
+    "verificationMethod": "did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1",
+    "challenge": "1f44d55f-f161-4938-a659-f8026467f126",
+    "domain": "4jt78h47fh47",
+    "jws": "..."
+  }
+}

--- a/test/v1.0.0/presentation-submission/example.json
+++ b/test/v1.0.0/presentation-submission/example.json
@@ -1,0 +1,38 @@
+{
+  "presentation_submission": {
+    "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+    "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "descriptor_map": [
+      {
+        "id": "banking_input_2",
+        "path": "$.verifiableCredential[0]",
+        "format": "jwt"
+      },
+      {
+        "id": "employment_input",
+        "path": "$.verifiableCredential[1]",
+        "format": "ldp_vc"
+      },
+      {
+        "id": "citizenship_input_1",
+        "path": "$.verifiableCredential[2]",
+        "format": "jwt_vp"
+      },
+      { 
+        "id": "banking_input_2",
+        "format": "jwt_vp",
+        "path": "$.outerCredential[0]",
+        "path_nested": {
+            "id": "banking_input_2",
+            "format": "ldp_vc",
+            "path": "$.innerCredential[1]",
+            "path_nested": {
+                "id": "banking_input_2",
+                "format": "jwt_vc",
+                "path": "$.mostInnerCredential[2]"
+            }
+        }
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-submission/nested_submission_example.json
+++ b/test/v1.0.0/presentation-submission/nested_submission_example.json
@@ -1,0 +1,23 @@
+{
+  "presentation_submission": {
+    "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+    "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "descriptor_map": [
+      {
+        "id": "banking_input_2",
+        "format": "jwt_vp",
+        "path": "$.outerClaim[0]",
+        "path_nested": {
+          "id": "banking_input_2",
+          "format": "ldp_vc",
+          "path": "$.innerClaim[1]",
+          "path_nested": {
+            "id": "banking_input_2",
+            "format": "jwt_vc",
+            "path": "$.mostInnerClaim[2]"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/v1.0.0/presentation-submission/schema.json
+++ b/test/v1.0.0/presentation-submission/schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Presentation Submission",
+  "type": "object",
+  "properties": {
+    "presentation_submission": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "definition_id": { "type": "string" },
+        "descriptor_map": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/descriptor" }
+        }
+      },
+      "required": ["id", "definition_id", "descriptor_map"],
+      "additionalProperties": false
+    }
+  },
+  "definitions": {
+    "descriptor": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "path": { "type": "string" },
+        "path_nested": {
+          "type": "object",
+            "$ref": "#/definitions/descriptor"
+        },
+        "format": {
+          "type": "string",
+          "enum": ["jwt", "jwt_vc", "jwt_vp", "ldp", "ldp_vc", "ldp_vp"]
+        }
+      },
+      "required": ["id", "path", "format"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["presentation_submission"],
+  "additionalProperties": false
+}

--- a/test/v1.0.0/presentation-submission/test.js
+++ b/test/v1.0.0/presentation-submission/test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const assert = require('assert');
+const ajv = require('ajv');
+
+
+describe('Presentation Submission', function () {
+  describe('JSON Schema', function () {
+    it('should validate the example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the nested submission example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/nested_submission_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the appendix VP example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      // Allow additional properties for this
+      schema.additionalProperties = true
+      const data = JSON.parse(fs.readFileSync(__dirname + '/appendix_VP_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the appendix OIDC example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      // Allow additional properties for this
+      schema.additionalProperties = true
+      const data = JSON.parse(fs.readFileSync(__dirname + '/appendix_OIDC_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+  });
+});

--- a/test/v1.0.0/submission-requirements/all_example.json
+++ b/test/v1.0.0/submission-requirements/all_example.json
@@ -1,0 +1,10 @@
+{
+  "submission_requirements": [
+    {
+      "name": "Submission of educational transcripts",
+      "purpose": "We need your complete educational transcripts to process your application",
+      "rule": "all",
+      "from": "A"
+    }
+  ]
+}

--- a/test/v1.0.0/submission-requirements/example.json
+++ b/test/v1.0.0/submission-requirements/example.json
@@ -1,0 +1,36 @@
+{
+  "submission_requirements": [
+    {
+      "name": "Banking Information",
+      "purpose": "We need you to prove you currently hold a bank account older than 12months.",
+      "rule": "pick",
+      "count": 1,
+      "from": "A"
+    },
+    {
+      "name": "Employment Information",
+      "purpose": "We are only verifying one current employment relationship, not any other information about employment.",
+      "rule": "all",
+      "from": "B"
+    },
+    {
+      "name": "Citizenship Information",
+      "rule": "pick",
+      "count": 1,
+      "from_nested": [
+        {
+          "name": "United States Citizenship Proofs",
+          "purpose": "We need you to prove your US citizenship.",
+          "rule": "all",
+          "from": "C"
+        },
+        {
+          "name": "European Union Citizenship Proofs",
+          "purpose": "We need you to prove you are a citizen of an EU member state.",
+          "rule": "all",
+          "from": "D"
+        }
+      ]
+    }
+  ]
+}

--- a/test/v1.0.0/submission-requirements/pick_1_example.json
+++ b/test/v1.0.0/submission-requirements/pick_1_example.json
@@ -1,0 +1,11 @@
+{
+  "submission_requirements": [
+    {
+      "name": "Citizenship Proof",
+      "purpose": "We need to confirm you are a citizen of one of the following countries before accepting your application",
+      "rule": "pick",
+      "count": 1,
+      "from": "B"
+    }
+  ]
+}

--- a/test/v1.0.0/submission-requirements/pick_2_example.json
+++ b/test/v1.0.0/submission-requirements/pick_2_example.json
@@ -1,0 +1,11 @@
+{
+  "submission_requirements": [
+    {
+      "name": "Eligibility to Work Proof",
+      "purpose": "We need to prove you are eligible for full-time employment in 2 or more of the following countries",
+      "rule": "pick",
+      "min": 2,
+      "from": "B"
+    }
+  ]
+}

--- a/test/v1.0.0/submission-requirements/pick_3_example.json
+++ b/test/v1.0.0/submission-requirements/pick_3_example.json
@@ -1,0 +1,14 @@
+{
+  "submission_requirements": [
+    {
+      "name": "Confirm banking relationship or employment and residence proofs",
+      "purpose": "Recent bank statements or proofs of both employment and residence will be validated to initiate your loan application but not stored",
+      "rule": "pick",
+      "count": 1,
+      "from_nested": [
+        { "rule": "all", "from": "A" },
+        { "rule": "pick", "count": 2, "from": "B" }
+      ]
+    }
+  ]
+}

--- a/test/v1.0.0/submission-requirements/schema.json
+++ b/test/v1.0.0/submission-requirements/schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "submission_requirements": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "name": { "type": "string" },
+            "purpose": { "type": "string" },
+            "rule": {
+              "type": "string",
+              "enum": ["all", "pick"]
+            },
+            "count": { "type": "integer", "minimum": 1 },
+            "min": { "type": "integer", "minimum": 0 },
+            "max": { "type": "integer", "minimum": 0 },
+            "from": { "type": "string" }
+          },
+          "required": ["rule", "from"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "name": { "type": "string" },
+            "purpose": { "type": "string" },
+            "rule": {
+              "type": "string",
+              "enum": ["all", "pick"]
+            },
+            "count": { "type": "integer", "minimum": 1 },
+            "min": { "type": "integer", "minimum": 0 },
+            "max": { "type": "integer", "minimum": 0 },
+            "from_nested": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/submission_requirements"
+              }
+            }
+          },
+          "required": ["rule", "from_nested"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "submission_requirements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/submission_requirements"
+      }
+    }
+  },
+  "required": ["submission_requirements"],
+  "additionalProperties": false
+}

--- a/test/v1.0.0/submission-requirements/test.js
+++ b/test/v1.0.0/submission-requirements/test.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const assert = require('assert');
+const ajv = require('ajv');
+
+/**
+ * https://github.com/decentralized-identity/presentation-exchange/pull/18/files#diff-9308a2575ae14de31b25f4459ecfc604R57
+ *
+ * from dhh1128:
+ * 	how do we express boolean options? I can see how we do the trivial ones
+ * 	(pick any N out of M). But that's not what I'm asking about. When I
+ * 	applied for citizenship for my daughter, I had to present any 2 proofs
+ * 	from category A, and any 1 proof from category B, OR I had to present 3
+ * 	or more proofs from category B. I don't see a way to model that
+ * 	real-world use case. It think that's because we imagine the rules to
+ * 	only exist *within* a single requirement, never across requirements.
+ * 	And we don't imagine arbitrary combinations of booleans.
+ *
+ * reponse here:
+ * 	we will support all of the above except for the "or more" specifier for
+ * 	now. The "or more" specifier can be implemented as a new rule as
+ * 	necessary.
+ **/
+
+describe('Submission Requirement', function () {
+  describe('JSON Schema', function () {
+    it('should validate the example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the all example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/all_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the pick 1 example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/pick_1_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the pick 2 example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/pick_2_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+
+    it('should validate the pick 3 example object using JSON Schema Draft 7', function () {
+      const schema = JSON.parse(fs.readFileSync(__dirname + '/schema.json'));
+      const data = JSON.parse(fs.readFileSync(__dirname + '/pick_3_example.json'));
+      const jv = new ajv({allErrors: true});
+      const validate = jv.compile(schema);
+      const valid = validate(data);
+
+      assert.equal(null, validate.errors);
+      assert.equal(true, valid);
+    });
+  });
+});


### PR DESCRIPTION
## Ultimate Problem
We have been updating the top-level test files for v2 but this also changes it for the v1 spec file

## Solution
- Add `v1.0.0` under `tests`
- Update insert paths in v1.0.0/spec.md

## Notes
- We could get the same result by just generating the cut version's spec file but that reduces readability in source code and it's still a good idea to have tests for previous versions of the spec