### PR TITLE
added format element to input_selector

### DIFF
--- a/test/presentation-definition/schema.json
+++ b/test/presentation-definition/schema.json
@@ -82,6 +82,7 @@
         "id": { "type": "string" },
         "name": { "type": "string" },
         "purpose": { "type": "string" },
+        "format": {"ref":"#/definitions/format"},
         "group": {
           "type": "array",
           "items": { "type": "string" }


### PR DESCRIPTION
This PR adds the `format` element to `input_descriptor` as specified in section 4.1.1 (https://identity.foundation/presentation-exchange/#input-descriptor-object).