### PR TITLE
Update Presentation Definition JSON Schema

### DIFF
--- a/test/presentation-definition/schema.json
+++ b/test/presentation-definition/schema.json
@@ -188,7 +188,7 @@
               "items": { "type": "string" }
             },
             "purpose": { "type": "string" },
-            "filter": { "$ref": "http://json-schema.org/schema#" }
+            "filter": { "$ref": "https://json-schema.org/draft-07/schema" }
           },
           "required": ["path"],
           "additionalProperties": false
@@ -201,7 +201,7 @@
               "items": { "type": "string" }
             },
             "purpose": { "type": "string" },
-            "filter": { "$ref": "http://json-schema.org/schema#" },
+            "filter": { "$ref": "https://json-schema.org/draft-07/schema" },
             "predicate": {
               "type": "string",
               "enum": ["required", "preferred"]

--- a/test/presentation-definition/schema.json
+++ b/test/presentation-definition/schema.json
@@ -188,7 +188,7 @@
               "items": { "type": "string" }
             },
             "purpose": { "type": "string" },
-            "filter": { "$ref": "https://json-schema.org/draft-07/schema#" }
+            "filter": { "$ref": "http://json-schema.org/draft-07/schema#" }
           },
           "required": ["path"],
           "additionalProperties": false
@@ -201,7 +201,7 @@
               "items": { "type": "string" }
             },
             "purpose": { "type": "string" },
-            "filter": { "$ref": "https://json-schema.org/draft-07/schema#" },
+            "filter": { "$ref": "http://json-schema.org/draft-07/schema#" },
             "predicate": {
               "type": "string",
               "enum": ["required", "preferred"]

--- a/test/presentation-definition/schema.json
+++ b/test/presentation-definition/schema.json
@@ -188,7 +188,7 @@
               "items": { "type": "string" }
             },
             "purpose": { "type": "string" },
-            "filter": { "$ref": "https://json-schema.org/draft-07/schema" }
+            "filter": { "$ref": "https://json-schema.org/draft-07/schema#" }
           },
           "required": ["path"],
           "additionalProperties": false
@@ -201,7 +201,7 @@
               "items": { "type": "string" }
             },
             "purpose": { "type": "string" },
-            "filter": { "$ref": "https://json-schema.org/draft-07/schema" },
+            "filter": { "$ref": "https://json-schema.org/draft-07/schema#" },
             "predicate": {
               "type": "string",
               "enum": ["required", "preferred"]


### PR DESCRIPTION
The prior link, `http://json-schema.org/schema#` is no longer supported / resolvable.
Updated to well-known link for the specific draft this specification uses.

Without this change, attempting to use the schema fails.