### PR TITLE
Remove Non-Normative JSON Schema Examples

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -376,7 +376,7 @@ be ignored, unless otherwise specified by a [[ref:Feature]];
           :::note IDO Filter
           Remember a valid JSON Schema ****MAY**** contain [additional keywords](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-01#section-6.4) (e.g., `formatMinimum` and `formatMaximum`) that require extensions to handle properly.
 
-          A [[ref: Holder]] ****MUST**** be able to gracefully handle additional properties, even if this just means ignoring the added keywords.
+          A [[ref: Holder]] ****SHOULD**** be able to gracefully handle additional properties, even if this just means ignoring the added keywords.
           :::
     - The _constraints object_ ****MAY**** contain a `limit_disclosure`
       property. If present, its value ****MUST**** be one of the following strings:

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -373,6 +373,11 @@ be ignored, unless otherwise specified by a [[ref:Feature]];
           used to filter against the values returned from evaluation of the
           [JSONPath](https://goessner.net/articles/JsonPath/) string
           expressions in the `path` array.
+          :::note IDO Filter
+          Remember a valid JSON Schema ****MAY**** contain [additional keywords](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-01#section-6.4) (e.g., `formatMinimum` and `formatMaximum`) that require extensions to handle properly.
+
+          A [[ref: Holder]] ****MUST**** be able to gracefully handle additional properties, even if this just means ignoring the added keywords.
+          :::
     - The _constraints object_ ****MAY**** contain a `limit_disclosure`
       property. If present, its value ****MUST**** be one of the following strings:
         - `required` - This indicates that the processing entity ****MUST****

--- a/test/presentation-definition/VC_expiration_example.json
+++ b/test/presentation-definition/VC_expiration_example.json
@@ -15,8 +15,7 @@
         "path": ["$.expirationDate"],
         "filter": {
           "type": "string",
-          "format": "date-time",
-          "formatMinimum": "2020-12-31T23:59:59.000Z"
+          "format": "date-time"
         }
       }
     ]

--- a/test/presentation-definition/basic_example.json
+++ b/test/presentation-definition/basic_example.json
@@ -48,8 +48,7 @@
               "path": ["$.credentialSubject.birth_date", "$.vc.credentialSubject.birth_date", "$.birth_date"],
               "filter": {
                 "type": "string",
-                "format": "date",
-                "formatMinimum": "1999-05-16"
+                "format": "date"
               }
             }
           ]

--- a/test/presentation-definition/multi_group_example.json
+++ b/test/presentation-definition/multi_group_example.json
@@ -201,8 +201,7 @@
               "purpose": "We must confirm that the driver was at least 21 years old on April 16, 2020.",
               "filter": {
                 "type": "string",
-                "format": "date",
-                "formatMaximum": "1999-05-16"
+                "format": "date"
               }
             }
           ]

--- a/test/presentation-definition/single_group_example.json
+++ b/test/presentation-definition/single_group_example.json
@@ -34,8 +34,7 @@
               "path": ["$.credentialSubject.dob", "$.vc.credentialSubject.dob", "$.dob"],
               "filter": {
                 "type": "string",
-                "format": "date",
-                "formatMaximum": "1999-06-15"
+                "format": "date"
               }
             }
           ]
@@ -58,8 +57,7 @@
               "path": ["$.credentialSubject.birth_date", "$.vc.credentialSubject.birth_date", "$.birth_date"],
               "filter": {
                 "type": "string",
-                "format": "date",
-                "formatMaximum": "1999-05-16"
+                "format": "date"
               }
             }
           ]


### PR DESCRIPTION
> Closes https://github.com/decentralized-identity/presentation-exchange/issues/312

## Ultimate Problem
The spec's examples included non-normative json schema for the `filter` property

## Solution
- Remove `formatMinimum` and `formatMaximum` from the examples
- Add text explaining JSON Schema extensions and calling out that Holders `SHOULD` gracefully handle additional/unknown keywords.
  - This is a `SHOULD` in the JSON Schema spec, so that's what I went with here