### PR TITLE
Clarify purpose field and privacy

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -278,7 +278,16 @@ be ignored, unless otherwise specified by a [[ref:Feature]];
 - `purpose` - The [[ref:Presentation Definition]] ****MAY**** contain a
   `purpose` property. If present, its value ****MUST**** be a string that
   describes the purpose for which the [[ref:Presentation Definition]]'s inputs
-  are being requested.
+  are being used for.
+  By including purpose it is not consent to process personal data but is only 
+  informative to the user. In certain jurisdictions the usage of the purpose 
+  field may be in conflict with the privacy regulatory requirements. The field
+  should not be included if prior data sharing agreements are not in place for
+  transferring personal data using presentation exchange.
+  Roadmap: DIF Claims & Credentials data agreement work group is developing an 
+  addition for privacy regulator compliance (GDPR, CCPA, other) and method for 
+  creating immutable records of consent records (data agreements) for using 
+  personal data.
 - The [[ref:Presentation Definition]] ****MAY**** include a `format` property.
   Some envelope transport protocols may include the value of this property in
   other locations and use different property names (See the [Format Embed Locations](#)


### PR DESCRIPTION
This change clarifies usage of purpose field and compliance with privacy regulation. An additional roadmap note is added but does not need to be included describing roadmap to address the regulatory issue. Issue #307