### PR TITLE
Ad intent_to_retain to input descripters, Issue 289

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -319,9 +319,9 @@ be ignored, unless otherwise specified by a [[ref:Feature]];
 [[ref:Verifier]] requires of a [[ref:Holder]]. All [[ref:Input Descriptors]]
 ****MUST**** be satisfied, unless otherwise specified by a [[ref:Feature]].
 
-[[ref: Input Descriptor Objects]] contain an identifier and may contain
- constraints on data values, and an explanation why a certain item or set of
-data is being requested.
+[[ref: Input Descriptor Objects]] contain an identifier, an intent to retain
+ indication and may contain constraints on data values, and an explanation why
+ a certain item or set of data is being requested.
 
 #### Input Descriptor Object
 
@@ -333,6 +333,17 @@ be ignored, unless otherwise specified by a [[ref:Feature]];
   The value of the `id` property ****MUST**** be a string that does not
   conflict with the `id` of another [[ref:Input Descriptor Object]] in the same
   [[ref:Presentation Definition]].
+- The [[ref:Input Descriptor Object]] ****MUST**** contain an `intent_to_retain`
+  property.
+  The value of the `intent_to_retain` property ****MUST**** be a boolean that 
+  indicates the [[ref:Verifier]] intents to retain the [[ref:Claim]]'s data being
+  requested.
+  A [[ref:Verifier]] shall not retain any data, including digests, signatures,
+  and derived data received, except for [[ref:Presentation Submission]] descriptors
+  for which the accompanying [[ref:Input Descriptor Object]]'s `intent_to_retain`
+  property was set to true.
+  Retain is defined as: “to store for a period longer than necessary to conduct the
+  exchange between [[ref:Holder]] and [[ref:Verifier]] in realtime”.
 - The [[ref:Input Descriptor Object]] ****MAY**** contain a `name` property. If
   present, its value ****SHOULD**** be a human-friendly name that describes what
   the target schema represents.

--- a/test/presentation-definition/VC_expiration_example.json
+++ b/test/presentation-definition/VC_expiration_example.json
@@ -1,5 +1,6 @@
 {
   "id": "drivers_license_information",
+  "intent_to_retain": false,
   "name": "Verify Valid License",
   "purpose": "We need you to show that your driver's license will be valid through December of this year.",
   "constraints": {

--- a/test/presentation-definition/VC_revocation_example.json
+++ b/test/presentation-definition/VC_revocation_example.json
@@ -1,5 +1,6 @@
 {
   "id": "drivers_license_information",
+  "intent_to_retain": false,
   "name": "Verify Valid License",
   "purpose": "We need to know that your license has not been revoked.",
   "constraints": {

--- a/test/presentation-definition/basic_example.json
+++ b/test/presentation-definition/basic_example.json
@@ -5,6 +5,7 @@
     "input_descriptors": [
       {
         "id": "bankaccount_input",
+        "intent_to_retain": true,
         "name": "Full Bank Account Routing Information",
         "purpose": "We can only remit payment to a currently-valid bank account, submitted as an ABA RTN + Acct # or IBAN.",
         "constraints": {
@@ -34,6 +35,7 @@
       },
       {
         "id": "us_passport_input",
+        "intent_to_retain": false,
         "name": "US Passport",
         "constraints": {
           "fields": [

--- a/test/presentation-definition/input_descriptor_id_tokens_example.json
+++ b/test/presentation-definition/input_descriptor_id_tokens_example.json
@@ -4,6 +4,7 @@
     "input_descriptors": [
       {
         "id": "employment_input_xyz_gov",
+        "intent_to_retain": false,
         "group": ["B"],
         "name": "Verify XYZ Government Employment",
         "purpose": "Verifying current employment at XYZ Government agency as proxy for permission to access this resource",

--- a/test/presentation-definition/input_descriptors_example.json
+++ b/test/presentation-definition/input_descriptors_example.json
@@ -1,6 +1,7 @@
 {
   "presentation_definition": {
     "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "intent_to_retain": true,
     "input_descriptors": [
       {
         "id": "banking_input_1",

--- a/test/presentation-definition/input_descriptors_example.json
+++ b/test/presentation-definition/input_descriptors_example.json
@@ -1,10 +1,10 @@
 {
   "presentation_definition": {
     "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
-    "intent_to_retain": true,
     "input_descriptors": [
       {
         "id": "banking_input_1",
+        "intent_to_retain": true,
         "name": "Bank Account Information",
         "purpose": "We can only remit payment to a currently-valid bank account.",
         "group": [

--- a/test/presentation-definition/minimal_example.json
+++ b/test/presentation-definition/minimal_example.json
@@ -2,6 +2,7 @@
   "comment": "Note: VP, OIDC, DIDComm, or CHAPI outer wrapper would be here.",
   "presentation_definition": {
     "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "intent_to_retain": false,
     "input_descriptors": [
       {
         "id": "wa_driver_license",

--- a/test/presentation-definition/multi_group_example.json
+++ b/test/presentation-definition/multi_group_example.json
@@ -27,6 +27,7 @@
     "input_descriptors": [
       {
         "id": "banking_input_1",
+        "intent_to_retain": true,
         "name": "Bank Account Information",
         "purpose": "Bank Account required to remit payment.",
         "group": ["A"],
@@ -99,6 +100,7 @@
       },
       {
         "id": "banking_input_2",
+        "intent_to_retain": true,
         "name": "Bank Account Information",
         "purpose": "We can only remit payment to a currently-valid bank account.",
         "group": ["A"],
@@ -152,6 +154,7 @@
       },
       {
         "id": "employment_input",
+        "intent_to_retain": true,
         "name": "Employment History",
         "purpose": "We are only verifying one current employment relationship, not any other information about employment.",
         "group": ["B"],
@@ -177,6 +180,7 @@
       },
       {
         "id": "drivers_license_input_1",
+        "intent_to_retain": false,
         "name": "EU Driver's License",
         "group": ["C"],
         "constraints": {
@@ -209,6 +213,7 @@
       },
       {
         "id": "drivers_license_input_2",
+        "intent_to_retain": false,
         "name": "Driver's License from one of 50 US States",
         "group": ["C"],
         "constraints": {

--- a/test/presentation-definition/pd_filter.json
+++ b/test/presentation-definition/pd_filter.json
@@ -4,6 +4,7 @@
     "input_descriptors": [
       {
         "id": "A specific type of VC",
+        "intent_to_retain": false,
         "name": "A specific type of VC",
         "purpose": "We want a VC of this type",
         "constraints": {

--- a/test/presentation-definition/pd_filter2.json
+++ b/test/presentation-definition/pd_filter2.json
@@ -4,6 +4,7 @@
     "input_descriptors": [
       {
         "id": "any type of credit card from any bank",
+        "intent_to_retain": true,
         "name": "any type of credit card from any bank",
         "purpose": "Please provide your credit card details",
         "constraints": {

--- a/test/presentation-definition/schemas/input-descriptor.json
+++ b/test/presentation-definition/schemas/input-descriptor.json
@@ -57,6 +57,7 @@
   "additionalProperties": false,
   "properties": {
     "id": { "type": "string" },
+    "intent_to_retain": { "type": "boolean" },
     "name": { "type": "string" },
     "purpose": { "type": "string" },
     "group": { "type": "array", "items": { "type": "string" } },

--- a/test/presentation-definition/schemas/presentation-definition-envelope.json
+++ b/test/presentation-definition/schemas/presentation-definition-envelope.json
@@ -57,6 +57,7 @@
       "additionalProperties": false,
       "properties": {
         "id": { "type": "string" },
+        "intent_to_retain": { "type": "boolean" },
         "name": { "type": "string" },
         "purpose": { "type": "string" },
         "group": { "type": "array", "items": { "type": "string" } },

--- a/test/presentation-definition/schemas/presentation-definition.json
+++ b/test/presentation-definition/schemas/presentation-definition.json
@@ -57,6 +57,7 @@
       "additionalProperties": false,
       "properties": {
         "id": { "type": "string" },
+        "intent_to_retain": { "type": "boolean" },
         "name": { "type": "string" },
         "purpose": { "type": "string" },
         "group": { "type": "array", "items": { "type": "string" } },

--- a/test/presentation-definition/single_group_example.json
+++ b/test/presentation-definition/single_group_example.json
@@ -11,6 +11,7 @@
     "input_descriptors": [
       {
         "id": "citizenship_input_1",
+        "intent_to_retain": false,
         "name": "EU Driver's License",
         "group": ["A"],
         "constraints": {
@@ -42,6 +43,7 @@
       },
       {
         "id": "citizenship_input_2",
+        "intent_to_retain": false,
         "name": "US Passport",
         "group": ["A"],
         "constraints": {


### PR DESCRIPTION
This PR adds the intent_to_retain property, discussed in #289 

Please note that the PR has the property as a **MUST**. As discussed in #289, I believe we need to do this to protect holders from verifiers (see also: https://blockchain.tno.nl/blog/verify-the-verifier-anti-coercion-by-design/)