### PR TITLE
Moving the claim-formats section out to a distinct, PR-able registry

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -321,7 +321,7 @@ be ignored, unless otherwise specified by a [[ref:Feature]];
 
 ::: note
   Including purpose information should not be confused with consent to process 
-  personal data NOR as a substitute for an, e.g., GDPR-conformant expression of 
+  personal data NOR taken as a substitute for an, e.g., GDPR-conformant expression of 
   "purpose"; instead, it should be thought of as purely informative to the user.
   Implementers are encouraged to do a proper review of applicable regulatory
   requirements around consent and purpose disclosures. 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1384,7 +1384,7 @@ add abbreviations for a claim format supported by a working implementation, plea
 follow [these instructions](https://identity.foundation/claim-format-registry/#structure-of-the-registry)
 and open a PR to open a pull request at the 
 [registry repository](https://github.com/decentralized-identity/claim-format-registry/).  
-This registry is not meant to be exhaustive or 
+This registry is not meant to be exhaustive nor 
 restrictive; an implementation that supports additional claim formats can still
 be considered fully conformant.
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -311,7 +311,9 @@ be ignored, unless otherwise specified by a [[ref:Feature]];
       format-specific algorithmic identifier references, as noted in the
       [Claim Format Designations](#claim-format-designations) section.
 
-      For example:
+      An illustrative example containing all of the formats in use by the
+      specifying implementers at time of writing (also reflected in the provided
+      JSON Schema) is as follows::
 
 ```json
 [[insert: ./test/presentation-definition/format_example.json]]

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1378,7 +1378,7 @@ the [[ref:Claim]].
 Within the _Presentation Exchange_ specification, there are numerous sections
 where [[ref:Verifiers]] and [[ref:Holders]] convey what [[ref:Claim]] variants
 they support and are submitting. The following are the normalized references
-used within the specification:
+used by the examples within the specification:
 
 - `jwt` - the format is a JSON Web Token (JWTs) [[spec:rfc7519]]
   that will be submitted in the form of a JWT encoded string. Expression of
@@ -1407,6 +1407,10 @@ used within the specification:
   be conveyed using a `proof_type` property paired with values that are
   identifiers from the
   [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/).
+
+::: note
+Note that the above is not an exhaustive list or a normative registry; it is merely the recommended core set upon which this specification was defined.
+:::
 
 ## JSON Schemas
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1372,7 +1372,6 @@ There are a number of mechanisms for safely embedding biometric information in a
 [[ref:Claim]] such that only a person who can confirm the biometric may present
 the [[ref:Claim]].
 
-
 ## Claim Format Designations
 
 Within the _Presentation Exchange_ specification, there are numerous sections
@@ -1382,8 +1381,10 @@ abbreviation tags which are defined in a separate
 [registry](https://identity.foundation/claim-format-registry/#registry) also 
 hosted at the DIF, and maintained by the same authors as this specification. To
 add abbreviations for a claim format supported by a working implementation, please
-follow these instructions and open a PR to open a pull request at the 
-[registry repository](https://identity.foundation/claim-format-registry/#structure-of-the-registry).  This registry is not meant to be exhaustive or 
+follow [these instructions](https://identity.foundation/claim-format-registry/#structure-of-the-registry)
+and open a PR to open a pull request at the 
+[registry repository](https://github.com/decentralized-identity/claim-format-registry/).  
+This registry is not meant to be exhaustive or 
 restrictive; an implementation that supports additional claim formats can still
 be considered fully conformant.
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1376,41 +1376,16 @@ the [[ref:Claim]].
 ## Claim Format Designations
 
 Within the _Presentation Exchange_ specification, there are numerous sections
-where [[ref:Verifiers]] and [[ref:Holders]] convey what [[ref:Claim]] variants
-they support and are submitting. The following are the normalized references
-used by the examples within the specification:
-
-- `jwt` - the format is a JSON Web Token (JWTs) [[spec:rfc7519]]
-  that will be submitted in the form of a JWT encoded string. Expression of
-  supported algorithms in relation to this format ****MUST**** be conveyed using
-  an `alg` property paired with values that are identifiers from the JSON Web
-  Algorithms registry [[spec:RFC7518]].
-- `jwt_vc`, `jwt_vp` - these formats are JSON Web Tokens (JWTs) [[spec:rfc7519]]
-  that will be submitted in the form of a JWT encoded string, and the body of
-  the decoded JWT string is defined in the JSON Web Token (JWT) [[spec:rfc7519]]
-  section of the
-  [W3C Verifiable Credentials specification](https://www.w3.org/TR/vc-data-model/#json-web-token).
-  Expression of supported algorithms in relation to these formats ****MUST****
-  be conveyed using an `alg` property paired with values that are identifiers
-  from the JSON Web Algorithms registry [[spec:RFC7518]].
-- `ldp` - the format is a Linked Data Proof [[ref:Linked Data Proofs]] that will
-  be submitted as an object.
-  Expression of supported algorithms in relation to these formats ****MUST****
-  be conveyed using a `proof_type` property with values that are identifiers
-  from the
-  [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/).
-- `ldp_vc`, `ldp_vp` - Verifiable Credential Linked Data Proof and Verifiable Presentation Linked
-  Data Proof formats. These are descriptions of formats normatively defined in the W3C Verifiable
-  Credentials specification [[spec:VC-DATA MODEL]], and will be submitted in the form of a JSON
-  object.
-  Expression of supported algorithms in relation to these formats ****MUST****
-  be conveyed using a `proof_type` property paired with values that are
-  identifiers from the
-  [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/).
-
-::: note
-Note that the above is not an exhaustive list or a normative registry; it is merely the recommended core set upon which this specification was defined.
-:::
+where [[ref:Verifiers]] and [[ref:Holders]] convey what [[ref:Claim]] format 
+variants they can receive or are submitting. These formats are codified by
+abbreviation tags which are defined in a separate 
+[registry](https://identity.foundation/claim-format-registry/#registry) also 
+hosted at the DIF, and maintained by the same authors as this specification. To
+add abbreviations for a claim format supported by a working implementation, please
+follow these instructions and open a PR to open a pull request at the 
+[registry repository](https://identity.foundation/claim-format-registry/#structure-of-the-registry).  This registry is not meant to be exhaustive or 
+restrictive; an implementation that supports additional claim formats can still
+be considered fully conformant.
 
 ## JSON Schemas
 


### PR DESCRIPTION
This would close #340.