### PR TITLE
Update example filters to work with arrays

### DIFF
--- a/test/presentation-definition/pd_filter.json
+++ b/test/presentation-definition/pd_filter.json
@@ -13,8 +13,11 @@
                 "$.type"
               ],
               "filter": {
-                "type": "string",
-                "pattern": "<the type of VC e.g. degree certificate>"
+                "type": "array",
+                "contains": {
+                  "type": "string",
+                  "pattern": "<the type of VC e.g. degree certificate>"
+                }
               }
             }
           ]

--- a/test/presentation-definition/pd_filter2.json
+++ b/test/presentation-definition/pd_filter2.json
@@ -10,29 +10,86 @@
           "fields": [
             {
               "path": [
-                "$.termsOfUse.type"
+                "$.termsOfUse"
               ],
               "filter": {
-                "type": "string",
-                "pattern": "https://train.trust-scheme.de/info"
-              }
-            },
-            {
-              "path": [
-                "$.termsOfUse.trustScheme"
-              ],
-              "filter": {
-                "type": "string",
-                "pattern": "worldbankfederation.com"
-              }
+                "$defs": {
+                  "typeString": {
+                    "type": "string",
+                    "pattern": "https://train.trust-scheme.de/info"
+                  },
+                  "typeStringOrArray": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/typeString"
+                      },
+                      {
+                        "type": "array",
+                        "contains": {
+                          "$ref": "#/$defs/typeString"
+                        }
+                      }
+                    ]
+                  },
+                  "trustSchemeString": {
+                    "type": "string",
+                    "pattern": "worldbankfederation.com"
+                  },
+                  "trustSchemeStringOrArray": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/trustSchemeString"
+                      },
+                      {
+                        "type": "array",
+                        "contains": {
+                          "$ref": "#/$defs/trustSchemeString"
+                        }
+                      }
+                    ]
+                  },
+                  "tosObject": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "trustScheme"
+                    ],
+                    "properties": {
+                      "type": {
+                        "$ref": "#/$defs/typeStringOrArray"
+                      },
+                      "trustScheme": {
+                        "$ref": "#/$defs/trustSchemeStringOrArray"
+                      }
+                    }
+                  },
+                  "tosObjectOrArray": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/tosObject"
+                      },
+                      {
+                        "type": "array",
+                        "contains": {
+                          "$ref": "#/$defs/tosObject"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "$ref": "#/$defs/tosObjectOrArray"
+              } 
             },
             {
               "path": [
                 "$.type"
               ],
               "filter": {
-                "type": "string",
-                "pattern": "creditCard"
+                "type": "array",
+                "contains": {
+                  "type": "string",
+                  "pattern": "creditCard"
+                }
               }
             }
           ]


### PR DESCRIPTION
This should address #420 by making the examples compatible with the real-world variability of the data formats. A few notes:

* Managing this optionality in JSON Schema within filters is pretty brutal, but I do think this reflects what it takes to use the current design to accomplish even these relatively simple objectives like "find creditCard VCs that participate in the worldbankfederation.com trust scheme".

* I'm not sure whether/when tests are run in the current build process. I tried `npm run test` on the main branch before making changes, and this failed with "Cannot find module '../__fixtures__/ajv'".

* It'd be nice to have tests that run the example filters against some "known matching" and "known non-matching" example VCs, but that's probably a consideration for another PR