### PR TITLE
Add JMandel's new example without overwriting simpler one

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -230,7 +230,7 @@ requirement.
   <button type="button">Minimal Example</button>
   <button type="button">Filter By Credential Type</button>
   <button type="button">Two Filters (Simplified)</button>
-  <button type="button">Two Filters (Complex)</button>
+  <button type="button">Two Filters (Real-World)</button>
 </nav>
 
 <section>

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -229,7 +229,8 @@ requirement.
 <nav>
   <button type="button">Minimal Example</button>
   <button type="button">Filter By Credential Type</button>
-  <button type="button">Two Filters</button>
+  <button type="button">Two Filters (Simplified)</button>
+  <button type="button">Two Filters (Complex)</button>
 </nav>
 
 <section>
@@ -254,7 +255,17 @@ requirement.
 
 <section>
 
-::: example Presentation Definition - Two Filters
+::: example Presentation Definition - Two Filters (Simplified)
+```json
+[[insert: ./test/presentation-definition/pd_filter2_simplified.json]]
+```
+:::
+
+</section>
+
+<section>
+
+::: example Presentation Definition - Two Filters (Complex)
 ```json
 [[insert: ./test/presentation-definition/pd_filter2.json]]
 ```

--- a/test/presentation-definition/pd_filter.json
+++ b/test/presentation-definition/pd_filter.json
@@ -13,8 +13,11 @@
                 "$.type"
               ],
               "filter": {
-                "type": "string",
-                "pattern": "<the type of VC e.g. degree certificate>"
+                "type": "array",
+                "contains": {
+                  "type": "string",
+                  "pattern": "<the type of VC e.g. degree certificate>"
+                }
               }
             }
           ]

--- a/test/presentation-definition/pd_filter2.json
+++ b/test/presentation-definition/pd_filter2.json
@@ -10,29 +10,86 @@
           "fields": [
             {
               "path": [
-                "$.termsOfUse.type"
+                "$.termsOfUse"
               ],
               "filter": {
-                "type": "string",
-                "pattern": "https://train.trust-scheme.de/info"
-              }
-            },
-            {
-              "path": [
-                "$.termsOfUse.trustScheme"
-              ],
-              "filter": {
-                "type": "string",
-                "pattern": "worldbankfederation.com"
-              }
+                "$defs": {
+                  "typeString": {
+                    "type": "string",
+                    "pattern": "https://train.trust-scheme.de/info"
+                  },
+                  "typeStringOrArray": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/typeString"
+                      },
+                      {
+                        "type": "array",
+                        "contains": {
+                          "$ref": "#/$defs/typeString"
+                        }
+                      }
+                    ]
+                  },
+                  "trustSchemeString": {
+                    "type": "string",
+                    "pattern": "worldbankfederation.com"
+                  },
+                  "trustSchemeStringOrArray": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/trustSchemeString"
+                      },
+                      {
+                        "type": "array",
+                        "contains": {
+                          "$ref": "#/$defs/trustSchemeString"
+                        }
+                      }
+                    ]
+                  },
+                  "tosObject": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "trustScheme"
+                    ],
+                    "properties": {
+                      "type": {
+                        "$ref": "#/$defs/typeStringOrArray"
+                      },
+                      "trustScheme": {
+                        "$ref": "#/$defs/trustSchemeStringOrArray"
+                      }
+                    }
+                  },
+                  "tosObjectOrArray": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/tosObject"
+                      },
+                      {
+                        "type": "array",
+                        "contains": {
+                          "$ref": "#/$defs/tosObject"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "$ref": "#/$defs/tosObjectOrArray"
+              } 
             },
             {
               "path": [
                 "$.type"
               ],
               "filter": {
-                "type": "string",
-                "pattern": "creditCard"
+                "type": "array",
+                "contains": {
+                  "type": "string",
+                  "pattern": "creditCard"
+                }
               }
             }
           ]

--- a/test/presentation-definition/pd_filter2_simplified.json
+++ b/test/presentation-definition/pd_filter2_simplified.json
@@ -1,0 +1,44 @@
+{
+    "presentation_definition": {
+      "id": "Scalable trust example",
+      "input_descriptors": [
+        {
+          "id": "any type of credit card from any bank",
+          "name": "any type of credit card from any bank",
+          "purpose": "Please provide your credit card details",
+          "constraints": {
+            "fields": [
+              {
+                "path": [
+                  "$.termsOfUse.type"
+                ],
+                "filter": {
+                  "type": "string",
+                  "pattern": "https://train.trust-scheme.de/info"
+                }
+              },
+              {
+                "path": [
+                  "$.termsOfUse.trustScheme"
+                ],
+                "filter": {
+                  "type": "string",
+                  "pattern": "worldbankfederation.com"
+                }
+              },
+              {
+                "path": [
+                  "$.type"
+                ],
+                "filter": {
+                  "type": "string",
+                  "pattern": "creditCard"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+  


### PR DESCRIPTION
Thank you for the swift PR, @jmandel ! We discussed #421 in today's meeting and were excited to see the array bug found and fixed, since many VCs in the realworld would fail this filter just for typing `type` as an array. We also thought the implicit conflict here between very simplified examples and the significant complexity needed to craft JSON Schema for real-world inputs IS something we should work on in future iterations of the protocol and implementation guide, so thanks for nudging us in that direction.

One nit we identified is that the examples are also test vectors, so rather than overwriting the `pd_filter2.json`, I created an alternate PR that preserved the simplified version for _testing_ purposes, and also for illustrative purposes.  This way, someone reading the examples from left to right will still see the high-level structure first, before being plunged into the brutality of real-world use-cases being encoded as JSON Schema :D 

If you feel this addresses #420 to your satisfaction give it a review and we'll merge this one; or, if you want to argue for further work on either PR, we can try that instead.