### PR TITLE
Use `https://` references in JSON schemas

### DIFF
--- a/schemas/presentation-definition-envelope.json
+++ b/schemas/presentation-definition-envelope.json
@@ -115,7 +115,7 @@
           "type": "string"
         },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
+          "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
         },
         "group": {
           "type": "array",
@@ -318,7 +318,7 @@
           "type": "string"
         },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json#"
+          "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json#"
         },
         "frame": {
           "type": "object",

--- a/schemas/presentation-definition.json
+++ b/schemas/presentation-definition.json
@@ -115,7 +115,7 @@
           "type": "string"
         },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
+          "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
         },
         "group": {
           "type": "array",
@@ -318,7 +318,7 @@
       "type": "string"
     },
     "format": {
-      "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
+      "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
     },
     "frame": {
       "type": "object",

--- a/schemas/presentation-submission.json
+++ b/schemas/presentation-submission.json
@@ -28,7 +28,7 @@
           "$ref": "#/definitions/descriptor"
         },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-submission-claim-format-designations.json#/definitions/format"
+          "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-submission-claim-format-designations.json#/definitions/format"
         }
       },
       "required": ["id", "path", "format"],

--- a/schemas/v2.0.0/presentation-definition-envelope.json
+++ b/schemas/v2.0.0/presentation-definition-envelope.json
@@ -115,7 +115,7 @@
           "type": "string"
         },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
+          "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
         },
         "group": {
           "type": "array",
@@ -318,7 +318,7 @@
           "type": "string"
         },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json#"
+          "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json#"
         },
         "frame": {
           "type": "object",

--- a/schemas/v2.0.0/presentation-definition.json
+++ b/schemas/v2.0.0/presentation-definition.json
@@ -115,7 +115,7 @@
           "type": "string"
         },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
+          "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
         },
         "group": {
           "type": "array",
@@ -318,7 +318,7 @@
       "type": "string"
     },
     "format": {
-      "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
+      "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
     },
     "frame": {
       "type": "object",

--- a/schemas/v2.0.0/presentation-submission.json
+++ b/schemas/v2.0.0/presentation-submission.json
@@ -28,7 +28,7 @@
           "$ref": "#/definitions/descriptor"
         },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-submission-claim-format-designations.json#/definitions/format"
+          "$ref": "https://identity.foundation/claim-format-registry/schemas/presentation-submission-claim-format-designations.json#/definitions/format"
         }
       },
       "required": ["id", "path", "format"],

--- a/test/__fixtures__/ajv.js
+++ b/test/__fixtures__/ajv.js
@@ -2,7 +2,7 @@ const Ajv = require('ajv');
 const addFormats = require('ajv-formats');
 
 const schemas = {
-  "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json": {
+  "https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Presentation Definition Claim Format Designations",
     "type": "object",
@@ -32,7 +32,7 @@ const schemas = {
       }
     }
   },
-  "http://identity.foundation/claim-format-registry/schemas/presentation-submission-claim-format-designations.json": {
+  "https://identity.foundation/claim-format-registry/schemas/presentation-submission-claim-format-designations.json": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Presentation Submission Claim Format Designations",
     "type": "object",


### PR DESCRIPTION
All of the other DIF schemas are using `https://` references to other schemas, not sure why the case is here that `http://` was used, but I think that should be changed. This is because validators can consider these two different schemas causing potentially two downloads and two compilings of the schemas. For us as we plan on having the schemas locally (not downloadable), we either have to have two entries or make local workaround (that replaces the http with https).

This PR is fixing this issue for this package schemas.