### PR TITLE
[WIP] Very rough stab at 2.1 addition of JSON Pointer

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -406,21 +406,26 @@ specified by a [[ref:Feature]]:
     earliest termination of evaluation. If the `fields` property is present,
     its value ****MUST**** be an array of objects composed as follows, unless
     otherwise specified by a feature:
-        - The _fields object_ ****MUST**** contain a `path` property. The value
-          of this property ****MUST**** be an array of one or more
-          [JSONPath](https://goessner.net/articles/JsonPath/) string
-          expressions (as defined in the
-          [JSONPath Syntax Definition](#jsonpath-syntax-definition) section)
-          that select a target value from the input. The array ****MUST****
-          be evaluated from 0-index forward, breaking as soon as a _Field
-          Query Result_ is found (as described in
-          [Input Evaluation](#input-evaluation)), which will be used for the
-          rest of the entry's evaluation. The ability to declare multiple
+        - The _fields object_ ****MUST**** contain either an array-valued `pointer`
+          or `path` property. The array ****MUST**** be evaluated from 0-index
+          forward, breaking as soon as a _Field Query Result_ is found (as
+          described in [Input Evaluation](#input-evaluation)), which will be used
+          for the rest of the entry's evaluation. The ability to declare multiple
           expressions in this way allows the [[ref:Verifier]] to account for
           format differences - for example: normalizing the differences in
           structure between JSON-LD/JWT-based
           [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) and
           vanilla JSON Web Tokens (JWTs) [[spec:rfc7519]].
+              - If provided, the `path` property ****MUST**** be an array of one or more
+          [JSONPath](https://goessner.net/articles/JsonPath/) string
+          expressions (as defined in the
+          [JSONPath Syntax Definition](#jsonpath-syntax-definition) section)
+          that select a target value from the input.
+              - If provided, the `pointer` property ****MUST**** be an array of one or more
+          [JSONPointer](TODO) string
+          expressions (as defined in the
+          [JSONPointer Syntax Definition](#jsonpointer-syntax-definition) section)
+          that select a target value from the input.
         - The _fields object_ ****MAY**** contain an `id` property. If present,
           its value ****MUST**** be a string that is unique from every other
           field object's `id` property, including those contained in other
@@ -434,14 +439,16 @@ specified by a [[ref:Feature]]:
         - The _fields object_ ****MAY**** contain a `filter` property, and if
           present its value ****MUST**** be a
           [JSON Schema](https://json-schema.org/specification.html) descriptor
-          used to filter against the values returned from evaluation of the
-          [JSONPath](https://goessner.net/articles/JsonPath/) string
-          expressions in the `path` array.
+          used to filter against the values returned from evaluation of one of:
+            - the [JSONPointer](https://goessner.net/articles/JsonPath/) string
+                expressions in the `pointer` array, if provided, OR
+            - the [JSONPath](https://goessner.net/articles/JsonPath/) string
+                expressions in the `path` array, if provided
         - The _fields object_ ****MAY**** contain an `optional` property. The value
           of this property ****MUST**** be a boolean, wherein `true` indicates the 
           field is optional, and `false` or non-presence of the property indicates 
           the field is required. Even when the `optional` property is present, the value 
-          located at the indicated `path` of the field ****MUST**** validate against 
+          located at the indicated `pointer` OR `path` of the field ****MUST**** validate against 
           the JSON Schema `filter`, if a `filter` is present.
           :::note IDO Filter
           Remember a valid JSON Schema ****MAY**** contain [additional keywords](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-01#section-6.4) (e.g., `formatMinimum` and `formatMaximum`) that require extensions to handle properly.
@@ -520,21 +527,33 @@ composed and embedded as follows:
       value of this property ****MUST**** be a string that matches one of the
       [Claim Format Designation](#claim-format-designations). This denotes the
       data format of the [[ref:Claim]].
-    - The `descriptor_map` object ****MUST**** include a `path` property. The
-      value of this property ****MUST**** be a
-      [JSONPath](https://goessner.net/articles/JsonPath/) string expression. The
-      `path` property indicates the [[ref:Claim]] submitted in relation to the
-      identified [[ref:Input Descriptor]], when executed against the top-level
-      of the object the [[ref:Presentation Submission]] is embedded within.
-    - The object ****MAY**** include a `path_nested` object to indicate the
+    - The `descriptor_map` object ****MUST**** include one of a `purpose` or `path` property:
+        - If provided, the value of the `pointer` property ****MUST**** be a
+        [JSONPointer](TODO) string expression. The
+        `pointer` property indicates the [[ref:Claim]] submitted in relation to the
+        identified [[ref:Input Descriptor]], when executed against the top-level
+        of the object the [[ref:Presentation Submission]] is embedded within.
+        - If provided, the value of the `path` property ****MUST**** be a
+        [JSONPath](https://goessner.net/articles/JsonPath/) string expression. The
+        `path` property indicates the [[ref:Claim]] submitted in relation to the
+        identified [[ref:Input Descriptor]], when executed against the top-level
+        of the object the [[ref:Presentation Submission]] is embedded within.
+    - The object ****MAY**** include one of a `pointer_nested` OR `path_nested` object to indicate the
       presence of a multi-[[ref:Claim]] envelope format. This means the
       [[ref:Claim]] indicated is to be decoded separately from its parent
       enclosure.
-      + The format of a `path_nested` object mirrors that of a `descriptor_map`
-        property. The nesting may be any number of levels deep. The `id`
+      + `pointer_nested`:
+          - The format of a `pointer_nested` object mirrors that of a `descriptor_map`
+            property. The nesting may be any number of levels deep. The `id`
         property ****MUST**** be the same for each level of nesting.
-      + The `path` property inside each `path_nested` property provides a
-        _relative path_ within a given nested value.
+          - The `pointer` property inside each `pointer_nested` property provides a
+            _relative pointer_ within a given nested value.
+      + `path_nested`:
+          - The format of a `path_nested` object mirrors that of a `descriptor_map`
+            property. The nesting may be any number of levels deep. The `id`
+        property ****MUST**** be the same for each level of nesting.
+          - The `path` property inside each `path_nested` property provides a
+            _relative path_ within a given nested value.
 
 ::: example Basic Presentation Submission object
 ```json


### PR DESCRIPTION
This is mostly a heads up that adding support for JSON Pointer and JSON Path in 2.1 will not be pretty.

I'll keep thinking of ways to clean it up. Here are the known todos I'll follow up with:
- Continue plumbing `pointer` variants of `path` throughout the spec
- Add examples using `pointer`
- Clarify impact on input evaluation
- Add section describing the rollout 
    - v2.1: pointer is preferred, but path is retained for backcompat
    - v3.0: path is moved out to a feature